### PR TITLE
Add msbuild import to identify where the metadata library is

### DIFF
--- a/build/Microsoft.Windows.SDK.Win32Metadata.props
+++ b/build/Microsoft.Windows.SDK.Win32Metadata.props
@@ -1,0 +1,9 @@
+<Project>
+  <PropertyGroup>
+    <MicrosoftWindowsSdkWin32MetadataBasePath>$(MSBuildThisFileDirectory)..\content\</MicrosoftWindowsSdkWin32MetadataBasePath>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- Provide the path to the winmd as input into the analyzer. -->
+    <CompilerVisibleProperty Include="MicrosoftWindowsSdkWin32MetadataBasePath" />
+  </ItemGroup>
+</Project>

--- a/sources/nuget/Microsoft.Windows.SDK.Win32Metadata/Microsoft.Windows.SDK.Win32Metadata.nuspec
+++ b/sources/nuget/Microsoft.Windows.SDK.Win32Metadata/Microsoft.Windows.SDK.Win32Metadata.nuspec
@@ -19,5 +19,6 @@
   <files>
       <file src="bin\Windows.Win32.winmd" target="content"/>
       <file src="bin\Windows.Win32.Interop.dll" target="content"/>
+      <file src="build\Microsoft.Windows.SDK.Win32Metadata.props" target="build\"/>
   </files>
 </package>


### PR DESCRIPTION
This allows the C# projection to read the path to the metadata dll from an msbuild property.
As a result, the projection nuget package can depend on the metadata package instead of embedding the dll directly, giving the consuming project author control over which version of the metadata to consume.