### PR TITLE
Fix GenerateMetadataSource.cmd 

### DIFF
--- a/GenerateMetadataSource.cmd
+++ b/GenerateMetadataSource.cmd
@@ -1,3 +1,3 @@
 @echo OFF
-pwsh.exe -NoLogo -NoProfile -ExecutionPolicy ByPass -Command "& """%~dp0scripts\GenerateMetadataSource.ps1""" %*"
+powershell.exe -NoLogo -NoProfile -ExecutionPolicy ByPass -Command "& """%~dp0scripts\GenerateMetadataSource.ps1""" %*"
 exit /B %ERRORLEVEL%


### PR DESCRIPTION
Not sure why this says `pwsh.exe`. That didn't work on my PC, so wonder if it's a local tool you have? The other scripts says `powershell.exe` and it works for me after changing it.