### PR TITLE
Pack winmd+dll into package root instead of content folder

### DIFF
--- a/buildTransitive/Microsoft.Windows.SDK.Win32Metadata.props
+++ b/buildTransitive/Microsoft.Windows.SDK.Win32Metadata.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <MicrosoftWindowsSdkWin32MetadataBasePath>$(MSBuildThisFileDirectory)..\content\</MicrosoftWindowsSdkWin32MetadataBasePath>
+    <MicrosoftWindowsSdkWin32MetadataBasePath>$(MSBuildThisFileDirectory)..\</MicrosoftWindowsSdkWin32MetadataBasePath>
   </PropertyGroup>
   <ItemGroup>
     <!-- Provide the path to the winmd as input into the analyzer. -->

--- a/sources/nuget/Microsoft.Windows.SDK.Win32Metadata/Microsoft.Windows.SDK.Win32Metadata.nuspec
+++ b/sources/nuget/Microsoft.Windows.SDK.Win32Metadata/Microsoft.Windows.SDK.Win32Metadata.nuspec
@@ -17,8 +17,8 @@
   </metadata>
 
   <files>
-      <file src="bin\Windows.Win32.winmd" target="content"/>
-      <file src="bin\Windows.Win32.Interop.dll" target="content"/>
+      <file src="bin\Windows.Win32.winmd" target=""/>
+      <file src="bin\Windows.Win32.Interop.dll" target=""/>
       <file src="buildTransitive\**" target="buildTransitive\"/>
       <file src="buildTransitive\**" target="build\"/>
   </files>


### PR DESCRIPTION
This prevents packages.config users from adding these two binaries as project content files.

Fixes #180