### PR TITLE
fix issue #211

### DIFF
--- a/sources/ClangSharpSourceToWinmd/MetadataSyntaxTreeCleaner.cs
+++ b/sources/ClangSharpSourceToWinmd/MetadataSyntaxTreeCleaner.cs
@@ -375,6 +375,10 @@ namespace ClangSharpSourceToWinmd
                     //    marshalAsType = "Bool";
                     //    break;
 
+                    case "LPCVOID":
+                        isConst = true;
+                        break;
+
                     case "PCHAR":
                     case "LPCH":
                     case "PCH":


### PR DESCRIPTION
Sets `isConst` to true for native type `LPCVOID` (aka. `const void*`).

After generating a new `Windows.Win32.winmd` file, I verified via ILSpy that `WriteFile` and `WriteFileEx` now properly show that the `lpBuffer` parameter is `[Const]`:

```C#
[DllImport("KERNEL32", ExactSpelling = true, SetLastError = true)]
public unsafe static extern BOOL WriteFile(
    [In] HANDLE hFile,
    [Optional][In][Const][NativeTypeInfo(UnmanagedType.LPArray, SizeParamIndex = 2)] void* lpBuffer,
    ...
);

[DllImport("KERNEL32", ExactSpelling = true, SetLastError = true)]
public unsafe static extern BOOL WriteFileEx(
    [In] HANDLE hFile,
    [Optional][In][Const][NativeTypeInfo(UnmanagedType.LPArray, SizeParamIndex = 2)] void* lpBuffer,
    ...
);
```