### PR TITLE
generation: Add DirectXShaderCompiler partition

### DIFF
--- a/generation/scraper/Partitions/DirectXShaderCompiler/main.cpp
+++ b/generation/scraper/Partitions/DirectXShaderCompiler/main.cpp
@@ -1,0 +1,10 @@
+#define SECURITY_WIN32 // For sspi.h
+#define QCC_OS_GROUP_WINDOWS
+
+#include "intrinfix.h"
+
+#include "windows.fixed.h"
+#include <sdkddkver.h>
+
+#include <dxcapi.h>
+// #include <dxcisense.h>

--- a/generation/scraper/Partitions/DirectXShaderCompiler/settings.rsp
+++ b/generation/scraper/Partitions/DirectXShaderCompiler/settings.rsp
@@ -1,0 +1,11 @@
+--file
+<PartitionDir>\main.cpp
+--output
+<GeneratedSourceDir>\<PartitionName>.cs
+--include-directory
+<RepoRoot>\generation\scraper
+<IncludeRoot>/um
+--traverse
+<IncludeRoot>/um/dxcapi.h
+--namespace
+Windows.Win32.Graphics.Hlsl


### PR DESCRIPTION
dxcapi.h is shipped with the SDK and used to interact with `dxcompiler.dll`: https://github.com/microsoft/DirectXShaderCompiler.
