### PR TITLE
Fix null => $null.

### DIFF
--- a/scripts/CommonUtils.ps1
+++ b/scripts/CommonUtils.ps1
@@ -110,7 +110,7 @@ function Get-VcDirPath
         }
     }
 
-    return null
+    return $null
 }
 
 function Get-OutputWinmdFileName


### PR DESCRIPTION
I noticed a small error when running `.\DoAll.ps1 -Clean`. PowerShell null is `$null`.