### PR TITLE
Log the ClangSharpPInvokeGenerator path and ensure the script doesn't fail for missing tools

### DIFF
--- a/scripts/CommonUtils.ps1
+++ b/scripts/CommonUtils.ps1
@@ -46,16 +46,16 @@ function Install-DotNetTool
 
     if ($Version -ne '')
     {
-        $installed = & dotnet tool list -g | select-string "$Name\s+$Version"
-        if (!$installed.Length)
+        $installed = & dotnet tool list -g | select-string -Pattern "$Name\s+$Version" -Raw
+        if (($installed -eq $null) -or !$installed.Length)
         {
             & dotnet tool update --global $Name --version $Version
         }
     }
     else
     {
-        $installed = & dotnet tool list -g | select-string "$Name"
-        if (!$installed.Length)
+        $installed = & dotnet tool list -g | select-string -Pattern "$Name" -Raw
+        if (($installed -eq $null) -or !$installed.Length)
         {
             & dotnet tool update --global $Name
         }

--- a/scripts/GenerateMetadataSource.ps1
+++ b/scripts/GenerateMetadataSource.ps1
@@ -42,6 +42,7 @@ $partitionNames = Get-ChildItem $partitionsDir | Select-Object -ExpandProperty N
 $stopwatch =  [system.diagnostics.stopwatch]::StartNew()
 
 Write-Output "`nProcessing each partition...using $throttleCount parallel script(s)"
+Write-Output "ClangSharpPInvokeGenerator resolved to $((Get-Command ClangSharpPInvokeGenerator).Path)"
 
 $errObj = new-object psobject
 Add-Member -InputObject $errObj -MemberType NoteProperty -Name ErrorCode -Value 0


### PR DESCRIPTION
These were found while testing https://github.com/microsoft/ClangSharp/pull/235.

In particular, it is useful to log the resolved path for `ClangSharpPInvokeGenerator` so it can be asserted to be the expected one (ClangSharp's CI test should override the global tool, for example).

Likewise, `Select-String` does not output a `string` by default, it outputs a `Microsoft.PowerShell.Commands.MatchInfo`: <https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/select-string?view=powershell-7.1#outputs> which does not have a Length property. It is expected that `-Raw` be passed if you want a `string`.

Additionally, if there is no match the result can be `$null`, which needs to be checked before getting the length.