### PR TITLE
Fix release notes link in Win32Docs

### DIFF
--- a/apidocs/Microsoft.Windows.SDK.Win32Docs/Microsoft.Windows.SDK.Win32Docs.targets
+++ b/apidocs/Microsoft.Windows.SDK.Win32Docs/Microsoft.Windows.SDK.Win32Docs.targets
@@ -1,8 +1,15 @@
 <Project>
 
-  <Target Name="PrepareReleaseNotes" BeforeTargets="GenerateNuspec" DependsOnTargets="GetBuildVersion">
+  <Target Name="PrepareReleaseNotes" BeforeTargets="GenerateNuspec">
+    <!-- The tag for the release built from this commit is based on the cloud build number, as calculated from the repo root.
+         See release.yml for more on that. -->
+    <Exec Command="nbgv get-version -v CloudBuildNumber -p ../.."
+          ConsoleToMSBuild="true"
+          StandardOutputImportance="low">
+      <Output TaskParameter="ConsoleOutput" PropertyName="ExpectedTagVersion" />
+    </Exec>
     <PropertyGroup>
-       <PackageReleaseNotes>https://github.com/microsoft/win32metadata/releases/tag/v$(Version)</PackageReleaseNotes>
+       <PackageReleaseNotes>https://github.com/microsoft/win32metadata/releases/tag/v$(ExpectedTagVersion)</PackageReleaseNotes>
     </PropertyGroup>
   </Target>
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -360,7 +360,8 @@ jobs:
     inputs:
       packageType: runtime
       version: 2.1.x
-
+  - powershell: dotnet tool install -g nbgv
+    displayName: ⚙ Install nbgv
   - script: dotnet pack -c $(BuildConfiguration)
     displayName: 📦 dotnet pack
     workingDirectory: apidocs


### PR DESCRIPTION
This gets the release notes link to be based on the tag that will eventually be created for this build rather than its own local version number.