### PR TITLE
Add a WebView2Sample with a StaticLibrary attribute mapping the DllImport name to an optional static library substitute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -358,7 +358,7 @@ MigrationBackup/
 /sources/CsWin32ProjectionLib/ProjectedWin32.cs
 /sources/CsWin32/Properties/launchSettings.json
 /.vscode/settings.json
-/tests/SourceToWinmd/source/generated
+/tests/SourceToWinmd/source/generated/fake/autotypes.cs
 /generation/emitter/generated
 /winsdk
 /generation/scraper/autoTypes.generated.rsp

--- a/sources/ClangSharpSourceToWinmd/ClangSharpSourceCompilation.cs
+++ b/sources/ClangSharpSourceToWinmd/ClangSharpSourceCompilation.cs
@@ -35,7 +35,8 @@ namespace ClangSharpSourceToWinmd
             Dictionary<string, string> typeImports,
             Dictionary<string, string> requiredNamespaces,
             HashSet<string> reducePointerLevels,
-            IEnumerable<string> addedRefs)
+            IEnumerable<string> addedRefs,
+            Dictionary<string, string> staticLibs)
         {
             sourceDirectory = Path.GetFullPath(sourceDirectory);
 
@@ -104,7 +105,7 @@ namespace ClangSharpSourceToWinmd
                     Directory.CreateDirectory(newSubDir);
                 }
 
-                var cleanedTree = MetadataSyntaxTreeCleaner.CleanSyntaxTree(tree, remaps, enumAdditions, enumsMakeFlagsHashSet, requiredNamespaces, emptyStucts, enumMemberNames, modifiedFile);
+                var cleanedTree = MetadataSyntaxTreeCleaner.CleanSyntaxTree(tree, remaps, enumAdditions, enumsMakeFlagsHashSet, requiredNamespaces, staticLibs, emptyStucts, enumMemberNames, modifiedFile);
 
                 lock (cleanedTrees)
                 {

--- a/sources/ClangSharpSourceToWinmd/Program.cs
+++ b/sources/ClangSharpSourceToWinmd/Program.cs
@@ -26,7 +26,8 @@ namespace ClangSharpSourceToWinmd
                 new Option<string>("--reducePointerLevel", "Reduce pointer level by one.", ArgumentArity.OneOrMore),
                 new Option<string>("--typeImport", "A type to be imported from another assembly.", ArgumentArity.OneOrMore),
                 new Option<string>("--requiredNamespaceForName", "The required namespace for a named item.", ArgumentArity.OneOrMore),
-                new Option<string>("--autoTypes", "An auto-type to add to the metadata.", ArgumentArity.OneOrMore)
+                new Option<string>("--autoTypes", "An auto-type to add to the metadata.", ArgumentArity.OneOrMore),
+                new Option<string>("--staticLibs", "Mapping from DLL names to alternative static libraries.", ArgumentArity.OneOrMore)
             };
 
             rootCommand.Handler = CommandHandler.Create(typeof(Program).GetMethod(nameof(Run)));
@@ -49,12 +50,14 @@ namespace ClangSharpSourceToWinmd
             var requiredNamespaceValuePairs = context.ParseResult.ValueForOption<string[]>("--requiredNamespaceForName");
             var autoTypes = context.ParseResult.ValueForOption<string[]>("--autoTypes");
             var refs = context.ParseResult.ValueForOption<string[]>("--ref");
+            var staticLibValuePairs = context.ParseResult.ValueForOption<string[]>("--staticLibs");
 
             var remaps = ConvertValuePairsToDictionary(remappedNameValuePairs);
             var enumAdditions = ConvertValuePairsToEnumAdditions(enumAdditionsNameValuePairs);
             var reducePointerLevels = new HashSet<string>(reducePointerLevelPairs ?? (new string[0]));
             var typeImports = ConvertValuePairsToDictionary(typeImportValuePairs);
             var requiredNamespaces = ConvertValuePairsToDictionary(requiredNamespaceValuePairs);
+            var staticLibs = ConvertValuePairsToDictionary(staticLibValuePairs);
 
             string rawVersion = version.Split('-')[0];
             Version assemblyVersion = Version.Parse(rawVersion);
@@ -82,7 +85,7 @@ namespace ClangSharpSourceToWinmd
 
             ClangSharpSourceCompilation clangSharpCompliation =
                 ClangSharpSourceCompilation.Create(
-                    sourceDirectory, arch, interopFileName, remaps, enumAdditions, enumMakeFlags, typeImports, requiredNamespaces, reducePointerLevels, refs);
+                    sourceDirectory, arch, interopFileName, remaps, enumAdditions, enumMakeFlags, typeImports, requiredNamespaces, reducePointerLevels, refs, staticLibs);
 
             Console.WriteLine("Looking for compilation errors...");
             var diags = clangSharpCompliation.GetDiagnostics();

--- a/sources/ClangSharpSourceToWinmd/Properties/launchSettings.json
+++ b/sources/ClangSharpSourceToWinmd/Properties/launchSettings.json
@@ -2,11 +2,11 @@
   "profiles": {
     "ClangSharpSourceToWinmd": {
       "commandName": "Project",
-      "commandLineArgs": "--sourceDir $(ProjectDir)..\\..\\generation\\emitter --arch crossarch --interopFileName $(ProjectDir)..\\Win32MetadataInterop\\bin\\Debug\\netstandard2.1\\Windows.Win32.Interop.dll --outputFileName $(ProjectDir)..\\..\\bin\\Windows.Win32.winmd --version 10.0.19041.5 @$(ProjectDir)..\\..\\generation\\emitter\\remap.rsp @$(ProjectDir)..\\..\\generation\\emitter\\autoTypes.rsp @$(ProjectDir)..\\..\\generation\\emitter\\requiredNamespacesForNames.rsp @$(ProjectDir)..\\..\\generation\\emitter\\generated\\x64\\enumsRemap.rsp @$(ProjectDir)..\\..\\generation\\emitter\\generated\\x64\\functionPointerFixups.generated.rsp @$(ProjectDir)..\\..\\generation\\emitter\\generated\\x64\\enumsMakeFlags.generated.rsp "
+      "commandLineArgs": "--sourceDir $(ProjectDir)..\\..\\generation\\emitter --arch crossarch --interopFileName $(ProjectDir)..\\Win32MetadataInterop\\bin\\Debug\\netstandard2.1\\Windows.Win32.Interop.dll --outputFileName $(ProjectDir)..\\..\\bin\\Windows.Win32.winmd --version 10.0.19041.5 @$(ProjectDir)..\\..\\generation\\emitter\\remap.rsp @$(ProjectDir)..\\..\\generation\\emitter\\autoTypes.rsp @$(ProjectDir)..\\..\\generation\\emitter\\requiredNamespacesForNames.rsp @$(ProjectDir)..\\..\\generation\\emitter\\generated\\x64\\enumsRemap.rsp @$(ProjectDir)..\\..\\generation\\emitter\\generated\\x64\\functionPointerFixups.generated.rsp @$(ProjectDir)..\\..\\generation\\emitter\\generated\\x64\\enumsMakeFlags.generated.rsp"
     },
     "TestSource": {
       "commandName": "Project",
-      "commandLineArgs": "-s $(ProjectDir)..\\..\\tests\\SourceToWinmd\\source -i $(ProjectDir)..\\Win32MetadataInterop\\bin\\Debug\\netstandard2.1\\Windows.Win32.Interop.dll -o$(ProjectDir)..\\..\\bin\\Test.winmd -v 10.0.15000.3-preview @$(ProjectDir)..\\..\\tests\\SourceToWinmd\\generation\\remap.rsp"
+      "commandLineArgs": "--sourceDir $(ProjectDir)..\\..\\tests\\SourceToWinmd\\source --arch fake --interopFileName $(ProjectDir)..\\Win32MetadataInterop\\bin\\Debug\\netstandard2.1\\Windows.Win32.Interop.dll --outputFileName $(ProjectDir)..\\..\\bin\\Test.winmd --version 10.0.15000.3-preview @$(ProjectDir)..\\..\\tests\\SourceToWinmd\\generation\\remap.rsp"
     }
   }
 }

--- a/sources/Win32MetadataInterop/StaticLibraryAttribute.cs
+++ b/sources/Win32MetadataInterop/StaticLibraryAttribute.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+namespace Windows.Win32.Interop
+{
+    /// <summary>
+    /// Indicates that the attributed method is defined in an unmanaged static library (LIB).
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    public class StaticLibraryAttribute : Attribute
+    {
+        /// <summary>
+        /// Initialize a new instance of <see cref="StaticLibraryAttribute"/> with the name of the LIB
+        /// file that contains the definition of this method.
+        /// </summary>
+        /// <param name="libName">
+        /// The name of the LIB file that contains the definition of this method.
+        /// </param>
+        public StaticLibraryAttribute(string libName)
+        {
+            this.Value = libName;
+        }
+
+        /// <summary>
+        /// Gets the name of a static library which may be substituted for the
+        /// <see cref="System.Runtime.InteropServices.DllImportAttribute"/> DLL.
+        /// </summary>
+        /// <value>
+        /// The name of the LIB file that contains the definition of this entry point.
+        /// </value>
+        public string Value { get; }
+    }
+}

--- a/sources/msbuild/WebView2SampleDebug/WebView2SampleDebug.proj
+++ b/sources/msbuild/WebView2SampleDebug/WebView2SampleDebug.proj
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+
+    <PropertyGroup>
+        <TaskBinDir>$(MSBuildThisFileDirectory)..\..\..\bin\release\netcoreapp3.1</TaskBinDir>
+        <ToolsBinDir>$(MSBuildThisFileDirectory)..\..\..\bin\release\netcoreapp3.1</ToolsBinDir>
+        <LibToolsBinDir>$(MSBuildThisFileDirectory)..\..\..\tools</LibToolsBinDir>
+        <Win32MetadataScraperAssetsDir>$(MSBuildThisFileDirectory)..\..\..\generation\scraper</Win32MetadataScraperAssetsDir>
+        <Win32MetadataScraperGeneratedAssetsDir>$(MSBuildThisFileDirectory)..\..\..\generation\scraper\obj\x64</Win32MetadataScraperGeneratedAssetsDir>
+    </PropertyGroup>
+
+    <Import Project="..\sdk\sdk.props" />
+
+    <PropertyGroup>
+        <OutputWinmd>bin\Windows.Web.WebView2.Win32.winmd</OutputWinmd>
+        <WinmdVersion>1.0.864.35</WinmdVersion>
+        <GenerateAssemblyVersionInfo>false</GenerateAssemblyVersionInfo>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <WebView2Headers Include="$(PkgMicrosoft_Web_WebView2)\**\*.h"/>
+        <WebView2Libs Include="$(PkgMicrosoft_Web_WebView2)\**\*.dll.lib"/>
+
+        <ImportLibs Include="@(WebView2Libs)">
+            <StaticLibs>WebView2Loader=WebView2LoaderStatic</StaticLibs>
+        </ImportLibs>
+
+        <Partition Include="main.cpp">
+            <TraverseFiles>@(WebView2Headers)</TraverseFiles>
+            <Namespace>Microsoft.Web.WebView2.Win32</Namespace>
+            <Exclude>CoreWebView2EnvironmentOptions</Exclude>
+        </Partition>
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Web.WebView2" Version="$(WinmdVersion)" GeneratePathProperty="true"/>
+    </ItemGroup>
+
+    <Import Project="..\sdk\sdk.targets" />
+</Project>

--- a/sources/msbuild/WebView2SampleDebug/WebView2SampleDebug.proj
+++ b/sources/msbuild/WebView2SampleDebug/WebView2SampleDebug.proj
@@ -12,7 +12,7 @@
     <Import Project="..\sdk\sdk.props" />
 
     <PropertyGroup>
-        <OutputWinmd>bin\Windows.Web.WebView2.Win32.winmd</OutputWinmd>
+        <OutputWinmd>bin\Microsoft.Web.WebView2.winmd</OutputWinmd>
         <WinmdVersion>1.0.864.35</WinmdVersion>
         <GenerateAssemblyVersionInfo>false</GenerateAssemblyVersionInfo>
     </PropertyGroup>

--- a/sources/msbuild/WebView2SampleDebug/main.cpp
+++ b/sources/msbuild/WebView2SampleDebug/main.cpp
@@ -1,0 +1,3 @@
+#include <windows.h>
+#include <WebView2.h>
+#include <WebView2EnvironmentOptions.h>

--- a/sources/msbuild/WebView2SampleDebug/nuget.config
+++ b/sources/msbuild/WebView2SampleDebug/nuget.config
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+  <disabledPackageSources>
+    <clear />
+  </disabledPackageSources>
+</configuration>

--- a/sources/msbuild/sdk/sdk.targets
+++ b/sources/msbuild/sdk/sdk.targets
@@ -36,6 +36,7 @@
                 PropertyName="EmitterSourceDir" />
         </ScrapeHeaders>
         <EmitWinmd
+            Libs="@(ImportLibs)"
             EmitterSourceDir="$(EmitterSourceDir)"
             ToolsBinDir="$(ToolsBinDir)"
             Win32WinmdBinDir="$(Win32WinmdBinDir)"

--- a/tests/SourceToWinmd/generation/remap.rsp
+++ b/tests/SourceToWinmd/generation/remap.rsp
@@ -1,9 +1,14 @@
 --autoTypes
-Windows.Win32.UI.WindowsAndMessaging,HWND,IntPtr
-Windows.Win32.System.SystemServices,BOOL,int
-Windows.Win32.System.SystemServices,WSTR,char*
-Windows.Win32.System.SystemServices,STR,byte*
-Windows.Win32.System.OleAutomation,BSTR,IntPtr,SysFreeString
+Windows.Win32.Foundation,HWND,DECLARE_HANDLE
+Windows.Win32.Foundation,BOOL,int
+Windows.Win32.Foundation,PWSTR,char*
+Windows.Win32.Foundation,PSTR,byte*
+Windows.Win32.Foundation,BSTR,char*,SysFreeString
+Windows.Win32.System.Memory,MEMORY_BASIC_INFORMATION,void*
 --remap
 MyStruct::X=MyEnum XX
 MyFunc::x=[In]MyEnum xx
+--requiredNamespaceForName
+SysFreeString=Windows.Win32.Test
+--staticLibs
+MyDll=MyStaticLib

--- a/tests/SourceToWinmd/source/generated/fake/test.cs
+++ b/tests/SourceToWinmd/source/generated/fake/test.cs
@@ -2,6 +2,9 @@
 using System;
 using System.Runtime.InteropServices;
 
+using Windows.Win32.Foundation;
+using Windows.Win32.System.Memory;
+
 using Windows.Win32.Interop;
 
 namespace Windows.Win32.Test
@@ -31,6 +34,9 @@ namespace Windows.Win32.Test
         [DllImport("OLEAUT32", ExactSpelling = true)]
         [return: NativeTypeName("BSTR")]
         public static extern ushort* SysAllocString([NativeTypeName("const OLECHAR *")][CppAttributeList("Name=SAL_name; p1=\"_In_opt_z_\"; p2=\"\"; p3=\"2\"^Name=SAL_begin^Name=SAL_name; p1=\"_In_opt_\"; p2=\"\"; p3=\"2\"^Name=SAL_pre^Name=SAL_notref^Name=SAL_null; p1=__maybe^Name=SAL_valid^Name=SAL_name; p1=\"_Deref_pre_readonly_\"; p2=\"\"; p3=\"1.1\"^Name=SAL_deref^Name=SAL_access; p1=0x1^Name=SAL_end^Name=SAL_nullTerminated; p1=__yes")] ushort* psz);
+
+        [DllImport("OLEAUT32", ExactSpelling = true)]
+        public static extern void SysFreeString([NativeTypeName("BSTR")] [CppAttributeList("Name=SAL_name; p1=\"_In_opt_\"; p2=\"\"; p3=\"2\"^Name=SAL_begin^Name=SAL_pre^Name=SAL_notref^Name=SAL_null; p1=__maybe^Name=SAL_valid^Name=SAL_name; p1=\"_Deref_pre_readonly_\"; p2=\"\"; p3=\"1.1\"^Name=SAL_deref^Name=SAL_access; p1=0x1^Name=SAL_end")] ushort* bstrString);
 
         [DllImport("MyDll", ExactSpelling = true, SetLastError = true)]
         public static extern int StringFunc([NativeTypeName("LPCWSTR")][CppAttributeList("Name=SAL_name; p1=\"_In_\"; p2=\"\"; p3=\"2\"^Name=SAL_begin^Name=SAL_pre^Name=SAL_notref^Name=SAL_null; p1=__no^Name=SAL_valid^Name=SAL_deref^Name=SAL_access; p1=0x1^Name=SAL_end")] ushort* szName, [NativeTypeName("LPWSTR")] sbyte* szFillMe, [NativeTypeName("DWORD")] uint dwLen);


### PR DESCRIPTION
Per https://github.com/microsoft/windows-rs/pull/729, there are times when it would be nice to link a static lib instead of importing an entry-point from the DLL. None of the libraries in `Windows.Win32.winmd` currently support this since I think they're all system DLLs, but when #66 is finished this is a capability that would make sense to include.

I tested this manually with `Windows.Win32.winmd` by mapping `USER32` to a `FakeStaticUser32` LIB in the launch settings for `ClangSharpSourceToWinmd`, then I revived the `TestSource` target and codified the test mapping `MyDll` to `MyStaticLib`.

The result is a new attribute on all of the functions imported from `MyDll` which looks like `[StaticLibrary("MyStaticLib")]`. This is in addition to the existing `[DllImport("MyDll", ...]` attributes which are unchanged, so consumers of the winmd file that don't know about `StaticLibraryAttribute` can safely ignore it.

I also merged in the change from #549 which adds a `NativeTypeName` attribute to any structs which are renamed by `ClangSharpPInvokeGenerator --remap`. (e.g. `[NativeTypeName("tagVARIANT")]` on `VARIANT`). That should reduce the dependency on files exported from this repo in the SDK NuGet, or enable an out-of-tree tool to interop with just the base winmd more easily.