### PR TITLE
Add null checks to ScrapeHeaders, ScanLibs to support no-lib scenarios

### DIFF
--- a/sources/msbuild/MetadataTasks/ScanLibs.cs
+++ b/sources/msbuild/MetadataTasks/ScanLibs.cs
@@ -85,15 +85,18 @@ namespace MetadataTasks
         private string[] GetLibs()
         {
             List<string> ret = new List<string>();
-            foreach (var libItem in this.Libs)
+            if (this.Libs != null)
             {
-                var libPath = libItem.ItemSpec;
-                if (!Path.IsPathRooted(libPath))
+                foreach (var libItem in this.Libs)
                 {
-                    libPath = Path.Combine(this.MSBuildProjectDirectory, libPath);
-                }
+                    var libPath = libItem.ItemSpec;
+                    if (!Path.IsPathRooted(libPath))
+                    {
+                        libPath = Path.Combine(this.MSBuildProjectDirectory, libPath);
+                    }
 
-                ret.Add(libPath);
+                    ret.Add(libPath);
+                }
             }
 
             return ret.ToArray();

--- a/sources/msbuild/MetadataTasks/ScrapeHeaders.cs
+++ b/sources/msbuild/MetadataTasks/ScrapeHeaders.cs
@@ -271,15 +271,18 @@ $@"--file
             AddWin32GeneratedRsp(args, "autoTypes.generated.rsp");
             AddWin32GeneratedRsp(args, "functionPointerFixups.generated.rsp");
 
-            foreach (var rspItem in this.Rsps)
+            if (this.Rsps != null)
             {
-                var rspPath = rspItem.ItemSpec;
-                if (!Path.IsPathRooted(rspPath))
+                foreach (var rspItem in this.Rsps)
                 {
-                    rspPath = Path.Combine(this.MSBuildProjectDirectory, rspPath);
-                }
+                    var rspPath = rspItem.ItemSpec;
+                    if (!Path.IsPathRooted(rspPath))
+                    {
+                        rspPath = Path.Combine(this.MSBuildProjectDirectory, rspPath);
+                    }
 
-                args.Append($" \"@{rspPath}\"");
+                    args.Append($" \"@{rspPath}\"");
+                }
             }
 
             int exitCode = TaskUtils.ExecuteCmd("ClangSharpPInvokeGenerator", args.ToString(), out var output, this.Log);


### PR DESCRIPTION
This change adds null checks around the response files collection in the `ScrapeHeaders` task and libs property in the `ScanLibs` task. Without these checks, the tasks fail in scenarios where no applicable static libs were found and/or no libs were specified for scaping operations.