### PR TITLE
Add AlternateSuccessCodes to IShellFolder::EnumObjects

### DIFF
--- a/generation/emitter/remap.rsp
+++ b/generation/emitter/remap.rsp
@@ -486,3 +486,4 @@ IUIAutomation::ElementFromHandle::hwnd=HWND
 IUIAutomation::ElementFromHandleBuildCache::hwnd=HWND
 GetNetworkParams::return=WIN32_ERROR
 DoDragDrop::return=[AlternateSuccessCodes]
+IShellFolder::EnumObjects::return=[AlternateSuccessCodes]

--- a/scripts/BaselineWinmd/Windows.Win32.winmd
+++ b/scripts/BaselineWinmd/Windows.Win32.winmd
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:97c3126737abd18f6aeebe8dba2a0ebffcfd28049bd9730012ddf2ee23c4cbce
+oid sha256:4dc1307e265d6ca32595d6429212800c39521f30a2b6f2b5f73f176aba062157
 size 13319680

--- a/scripts/BaselineWinmd/Windows.Win32.winmd
+++ b/scripts/BaselineWinmd/Windows.Win32.winmd
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0333349add2c66b8f7e54fe631c83815b8e5a0458ceccd9f8c4b078d7b4585cd
+oid sha256:1f3629ac85c5742cce7598da65278a57621c3f7328f992ab3caaae66ab3102d9
 size 13318656


### PR DESCRIPTION
According to https://docs.microsoft.com/en-us/windows/win32/api/shobjidl_core/nf-shobjidl_core-ishellfolder-enumobjects

> Returns `S_OK` if successful, or an error value otherwise. Some implementations may also return `S_FALSE`, indicating that there are no children matching the grfFlags that were passed in.