### PR TITLE
Create msbuild ProjectionMetadataWinmd item in package import

### DIFF
--- a/apidocs/Microsoft.Windows.SDK.Win32Docs/buildTransitive/Microsoft.Windows.SDK.Win32Docs.props
+++ b/apidocs/Microsoft.Windows.SDK.Win32Docs/buildTransitive/Microsoft.Windows.SDK.Win32Docs.props
@@ -1,9 +1,5 @@
 <Project>
-  <PropertyGroup>
-    <MicrosoftWindowsSdkApiDocsPath>$(MSBuildThisFileDirectory)..\apidocs.msgpack</MicrosoftWindowsSdkApiDocsPath>
-  </PropertyGroup>
   <ItemGroup>
-    <!-- Provide the path to the winmd as input into the analyzer. -->
-    <CompilerVisibleProperty Include="MicrosoftWindowsSdkApiDocsPath" />
+    <ProjectionDocs Include="$(MSBuildThisFileDirectory)..\apidocs.msgpack" />
   </ItemGroup>
 </Project>

--- a/buildTransitive/Microsoft.Windows.SDK.Win32Metadata.props
+++ b/buildTransitive/Microsoft.Windows.SDK.Win32Metadata.props
@@ -1,9 +1,5 @@
 <Project>
-  <PropertyGroup>
-    <MicrosoftWindowsSdkWin32MetadataBasePath>$(MSBuildThisFileDirectory)..\</MicrosoftWindowsSdkWin32MetadataBasePath>
-  </PropertyGroup>
   <ItemGroup>
-    <!-- Provide the path to the winmd as input into the analyzer. -->
-    <CompilerVisibleProperty Include="MicrosoftWindowsSdkWin32MetadataBasePath" />
+    <ProjectionMetadataWinmd Include="$(MSBuildThisFileDirectory)..\Windows.Win32.winmd" />
   </ItemGroup>
 </Project>

--- a/sources/msbuild/DiaSdk/buildTransitive/Microsoft.Dia.Win32Metadata.props
+++ b/sources/msbuild/DiaSdk/buildTransitive/Microsoft.Dia.Win32Metadata.props
@@ -1,9 +1,5 @@
 <Project>
-  <PropertyGroup>
-    <MicrosoftWindowsSdkWin32MetadataBasePath>$(MSBuildThisFileDirectory)..\</MicrosoftWindowsSdkWin32MetadataBasePath>
-  </PropertyGroup>
   <ItemGroup>
-    <!-- Provide the path to the winmd as input into the analyzer. -->
-    <CompilerVisibleProperty Include="MicrosoftWindowsSdkWin32MetadataBasePath" />
+    <ProjectionMetadataWinmd Include="$(MSBuildThisFileDirectory)..\Microsoft.Dia.winmd" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Instead of setting the `MicrosoftWindowsSdkWin32MetadataBasePath` msbuild property, which is a scalar and only allows one assignment, we now add to an msbuild item list so that projections (e.g. CsWin32) may consume many such metadata winmds in one build.

https://github.com/microsoft/CsWin32/pull/386 will consume this change.