### PR TITLE
Add missing console input mode flags

### DIFF
--- a/generation/emitter/manual/Console.manual.cs
+++ b/generation/emitter/manual/Console.manual.cs
@@ -7,19 +7,24 @@ namespace Windows.Win32.System.Console
     [Flags]
     public enum CONSOLE_MODE : uint
     {
-        ENABLE_ECHO_INPUT = 0x0004,
-        ENABLE_INSERT_MODE = 0x0020,
-        ENABLE_LINE_INPUT = 0x0002,
-        ENABLE_MOUSE_INPUT = 0x0010,
+        // Input mode flags
         ENABLE_PROCESSED_INPUT = 0x0001,
-        ENABLE_QUICK_EDIT_MODE = 0x0040,
+        ENABLE_LINE_INPUT = 0x0002,
+        ENABLE_ECHO_INPUT = 0x0004,
         ENABLE_WINDOW_INPUT = 0x0008,
+        ENABLE_MOUSE_INPUT = 0x0010,
+        ENABLE_INSERT_MODE = 0x0020,
+        ENABLE_QUICK_EDIT_MODE = 0x0040,
+        ENABLE_EXTENDED_FLAGS = 0x0080,
+        ENABLE_AUTO_POSITION = 0x0100,
         ENABLE_VIRTUAL_TERMINAL_INPUT = 0x0200,
+        
+        // Output mode flags
         ENABLE_PROCESSED_OUTPUT = 0x0001,
         ENABLE_WRAP_AT_EOL_OUTPUT = 0x0002,
         ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004,
         DISABLE_NEWLINE_AUTO_RETURN = 0x0008,
-        ENABLE_LVB_GRID_WORLDWIDE = 0x0010
+        ENABLE_LVB_GRID_WORLDWIDE = 0x0010,
     }
     
     public enum STD_HANDLE : uint


### PR DESCRIPTION
Fixes #642.

Added ENABLE_EXTENDED_FLAGS, ENABLE_AUTO_POSITION.

Also re-ordered the values to align with `consoleapi.h` for easier reading. I've tested for ABI impact via `Enum.GetValues` and observed no ill effects.