### PR TITLE
Add conditions to globbing

### DIFF
--- a/sources/msbuild/GeneratorSample/GeneratorSample.proj
+++ b/sources/msbuild/GeneratorSample/GeneratorSample.proj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <DWriteHeaders Include="$(PkgMicrosoft_ProjectReunion_DWrite)\**\*.h"/>
-    <DWriteLibs Include="$(PkgMicrosoft_ProjectReunion_DWrite)\**\*.lib"/>
+    <DWriteHeaders Condition=" '$(PkgMicrosoft_ProjectReunion_DWrite)' != '' " Include="$(PkgMicrosoft_ProjectReunion_DWrite)\**\*.h"/>
+    <DWriteLibs Condition=" '$(PkgMicrosoft_ProjectReunion_DWrite)' != '' " Include="$(PkgMicrosoft_ProjectReunion_DWrite)\**\*.lib"/>
 
     <ImportLibs Include="@(DWriteLibs)"/>
     <Partition Include="main.cpp">

--- a/sources/msbuild/GeneratorSampleDebug/GeneratorSampleDebug.proj
+++ b/sources/msbuild/GeneratorSampleDebug/GeneratorSampleDebug.proj
@@ -20,8 +20,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <DWriteHeaders Include="$(PkgMicrosoft_ProjectReunion_DWrite)\**\*.h"/>
-    <DWriteLibs Include="$(PkgMicrosoft_ProjectReunion_DWrite)\**\*.lib"/>
+    <DWriteHeaders Condition=" '$(PkgMicrosoft_ProjectReunion_DWrite)' != '' " Include="$(PkgMicrosoft_ProjectReunion_DWrite)\**\*.h"/>
+    <DWriteLibs Condition=" '$(PkgMicrosoft_ProjectReunion_DWrite)' != '' " Include="$(PkgMicrosoft_ProjectReunion_DWrite)\**\*.lib"/>
 
     <ImportLibs Include="@(DWriteLibs)"/>
     <Partition Include="main.cpp">

--- a/sources/msbuild/WebView2SampleDebug/WebView2SampleDebug.proj
+++ b/sources/msbuild/WebView2SampleDebug/WebView2SampleDebug.proj
@@ -20,8 +20,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <WebView2Headers Include="$(PkgMicrosoft_Web_WebView2)\**\*.h"/>
-    <WebView2Libs Include="$(PkgMicrosoft_Web_WebView2)\**\*.dll.lib"/>
+    <WebView2Headers Condition=" '$(PkgMicrosoft_Web_WebView2)' != '' " Include="$(PkgMicrosoft_Web_WebView2)\**\*.h"/>
+    <WebView2Libs Condition=" '$(PkgMicrosoft_Web_WebView2)' != '' " Include="$(PkgMicrosoft_Web_WebView2)\**\*.dll.lib"/>
 
     <ImportLibs Include="@(WebView2Libs)">
       <StaticLibs>WebView2Loader=WebView2LoaderStatic</StaticLibs>


### PR DESCRIPTION
Without these, msbuild evaluation of these projects takes 2-4 minutes to search my entire hard drive for these files, given the base property isn't set at restore time.