### PR TITLE
Fixes #644 - Specify version of Microsoft.Build.NoTargets when doing Import

### DIFF
--- a/sources/GeneratorSdk/sdk/sdk.props
+++ b/sources/GeneratorSdk/sdk/sdk.props
@@ -4,7 +4,7 @@
     <MicrosoftNoTargetsSdkImported Condition="'$(UsingMicrosoftNoTargetsSdk)' != 'true'">true</MicrosoftNoTargetsSdkImported>
   </PropertyGroup>
 
-  <Import Condition="'$(UsingMicrosoftNoTargetsSdk)' != 'true'" Sdk="Microsoft.Build.NoTargets" Project="sdk.props"/>
+  <Import Condition="'$(UsingMicrosoftNoTargetsSdk)' != 'true'" Sdk="Microsoft.Build.NoTargets" Version="3.0.4" Project="sdk.props"/>
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>

--- a/sources/GeneratorSdk/sdk/sdk.targets
+++ b/sources/GeneratorSdk/sdk/sdk.targets
@@ -63,5 +63,5 @@
     <RemoveDir Directories="obj;bin" />
   </Target>
 
-  <Import Condition="'$(MicrosoftNoTargetsSdkImported)' == 'true'" Sdk="Microsoft.Build.NoTargets" Project="sdk.targets"/>
+  <Import Condition="'$(MicrosoftNoTargetsSdkImported)' == 'true'" Sdk="Microsoft.Build.NoTargets" Version="3.0.4" Project="sdk.targets"/>
 </Project>


### PR DESCRIPTION
We need to specify a version of Microsoft.Build.NoTargets when we Import it in the props and targets. This didn't fail the build because we have a global.json with Microsoft.Build.NoTargets in it, which most users won't have.