### PR TITLE
Capture undecorated symbol names from dumpbin output

### DIFF
--- a/sources/GeneratorSdk/MetadataTasks/ScanLibs.cs
+++ b/sources/GeneratorSdk/MetadataTasks/ScanLibs.cs
@@ -32,7 +32,7 @@ namespace MetadataTasks
             string[] libFiles = this.GetLibs();
             string dumpBinPath = Path.Combine(this.LibToolsBinDir, "dumpbin.exe");
             var libLines = new StringBuilder();
-            var libRegex = new Regex(@"DLL name     : (\S+)\s+Symbol name  : (\S+)");
+            var libRegex = new Regex(@"DLL name     : (\S+)(?:\r|\n.*){6,}?\s+Name         : (\S+)");
             var functionNames = new HashSet<string>(System.StringComparer.OrdinalIgnoreCase);
             foreach (var lib in libFiles)
             {


### PR DESCRIPTION
Fixes #689.

Alters the regular expression to instead capture undecorated symbol names.