### PR TITLE
Add additional DIA excludes, types

### DIFF
--- a/sources/GeneratorSdk/samples/DiaSdk/Dia.manual.cs
+++ b/sources/GeneratorSdk/samples/DiaSdk/Dia.manual.cs
@@ -82,5 +82,65 @@ namespace Microsoft.Dia
 
         [NativeTypeName("HRESULT")]
         public const int E_PDB_OBJECT_DISPOSED = E_PDB_OK + 25;
+
+        [NativeTypeName("HRESULT")]
+        public const int E_DIA_INPROLOG = unchecked((int)(((uint)(1)<<31) | ((uint)(((uint)0x6d))<<16) | ((uint)(100))));
+
+        [NativeTypeName("HRESULT")]
+        public const int E_DIA_SYNTAX = E_DIA_INPROLOG + 1;
+
+        [NativeTypeName("HRESULT")]
+        public const int E_DIA_FRAME_ACCESS = E_DIA_INPROLOG + 2;
+
+        [NativeTypeName("HRESULT")]
+        public const int E_DIA_VALUE = E_DIA_INPROLOG + 3;
+    }
+
+    public enum SymTag
+    {
+        SymTagNull,
+        SymTagExe,
+        SymTagCompiland,
+        SymTagCompilandDetails,
+        SymTagCompilandEnv,
+        SymTagFunction,
+        SymTagBlock,
+        SymTagData,
+        SymTagAnnotation,
+        SymTagLabel,
+        SymTagPublicSymbol,
+        SymTagUDT,
+        SymTagEnum,
+        SymTagFunctionType,
+        SymTagPointerType,
+        SymTagArrayType,
+        SymTagBaseType,
+        SymTagTypedef,
+        SymTagBaseClass,
+        SymTagFriend,
+        SymTagFunctionArgType,
+        SymTagFuncDebugStart,
+        SymTagFuncDebugEnd,
+        SymTagUsingNamespace,
+        SymTagVTableShape,
+        SymTagVTable,
+        SymTagCustom,
+        SymTagThunk,
+        SymTagCustomType,
+        SymTagManagedType,
+        SymTagDimension,
+        SymTagCallSite,
+        SymTagInlineSite,
+        SymTagBaseInterface,
+        SymTagVectorType,
+        SymTagMatrixType,
+        SymTagHLSLType,
+        SymTagCaller,
+        SymTagCallee,
+        SymTagExport,
+        SymTagHeapAllocationSite,
+        SymTagCoffGroup,
+        SymTagInlinee,
+        SymTagMax
     }
 }

--- a/sources/GeneratorSdk/samples/DiaSdk/options.rsp
+++ b/sources/GeneratorSdk/samples/DiaSdk/options.rsp
@@ -1,6 +1,8 @@
 --exclude
-__MIDL___MIDL_itf_dia2_0000_0033_0001
+SymTagEnum
 __MIDL___MIDL_itf_dia2_0000_0000_0001
+__MIDL___MIDL_itf_dia2_0000_0033_0001
 PfnPDBDebugDirV
 --remap
-__MIDL___MIDL_itf_dia2_0000_0042_0001=FPODATA
+SymTagEnum=SymTag
+__MIDL___MIDL_itf_dia2_0000_0043_0001=FPODATA


### PR DESCRIPTION
* Excludes anonymous enum __MIDL___MIDL_itf_dia2_0000_0034_0001; manually defines those HRESULTs.
* Excludes SymTagEnum enum; manually defines SymTag (subjectively) to prevent clashing with enumerator with name SymTagEnum.
* Corrects FPODATA remapping

For your reference:
```csharp
public enum __MIDL___MIDL_itf_dia2_0000_0034_0001
{
	E_DIA_INPROLOG = -2140340124,
	E_DIA_SYNTAX,
	E_DIA_FRAME_ACCESS,
	E_DIA_VALUE
}
```