### PR TITLE
Move window message constants from RichEdit namespace

### DIFF
--- a/generation/WinSDK/requiredNamespacesForNames.rsp
+++ b/generation/WinSDK/requiredNamespacesForNames.rsp
@@ -2410,3 +2410,9 @@ PROPSPEC_KIND=Windows.Win32.System.Com.StructuredStorage
 TYSPEC=Windows.Win32.System.Com
 VARENUM=Windows.Win32.System.Ole
 # endregion wtypes.h
+# region richedit.h
+WM_CONTEXTMENU=Windows.Win32.UI.WindowsAndMessaging
+WM_UNICHAR=Windows.Win32.UI.WindowsAndMessaging
+WM_PRINTCLIENT=Windows.Win32.UI.WindowsAndMessaging
+WM_NOTIFY=Windows.Win32.UI.WindowsAndMessaging
+# endregion

--- a/scripts/BaselineWinmd/Windows.Win32.winmd
+++ b/scripts/BaselineWinmd/Windows.Win32.winmd
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0bd9fd6eb031cd3ad4062aca5b31ebe0931581453c7e251f0b880c8643633ab3
+oid sha256:4d99cb8fe86f80ff221837f14a3d2f074e588ca0310857e563d2f93bac3d770c
 size 16123392


### PR DESCRIPTION
Moves some straggler window message constants from `Win32.UI.Controls.RichEdit` to `Win32.UI.WindowsAndMessaging`.

Fixes #795.

Metadata diff:
```
Windows.Win32.UI.Controls.RichEdit.Apis.WM_CONTEXTMENU => Windows.Win32.UI.WindowsAndMessaging.Apis.WM_CONTEXTMENU
Windows.Win32.UI.Controls.RichEdit.Apis.WM_UNICHAR => Windows.Win32.UI.WindowsAndMessaging.Apis.WM_UNICHAR
Windows.Win32.UI.Controls.RichEdit.Apis.WM_PRINTCLIENT => Windows.Win32.UI.WindowsAndMessaging.Apis.WM_PRINTCLIENT
Windows.Win32.UI.Controls.RichEdit.Apis.WM_NOTIFY => Windows.Win32.UI.WindowsAndMessaging.Apis.WM_NOTIFY
```