### PR TITLE
Temporarily disable PowerShell strict mode

### DIFF
--- a/scripts/CommonUtils.ps1
+++ b/scripts/CommonUtils.ps1
@@ -8,7 +8,12 @@ $sdkGeneratedSourceDir = "$windowsWin32ProjectRoot\obj\generated"
 $recompiledIdlHeadersDir = "$windowsWin32ProjectRoot\RecompiledIdlHeaders"
 $metadataToolsBin = "$binDir\release\net5.0"
 
-Set-StrictMode -Version Latest
+# [VS 1673159]
+# Temporarily disable strict mode to address bug introduced
+# in Visual Studio 17.1.0 that impacts vsdevshell launch
+#
+# Set-StrictMode -Version Latest
+
 $ErrorActionPreference = "Stop"
 
 # This messes up parallel loops


### PR DESCRIPTION
Temporarily disables calling [Set-StrictMode](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/set-strictmode?view=powershell-7.2&WT.mc_id=WD-MVP-5002756) due to an issue discovered in [Visual Studio 17.1.0](https://developercommunity.visualstudio.com/t/launch-vsdevshell-no-longer-works-in-strict-mode/1673159).

Fixes build failures impacting #811.


