### PR TITLE
Add SetLastError attribute to additional Di APIs

### DIFF
--- a/generation/WinSDK/WithSetLastError.rsp
+++ b/generation/WinSDK/WithSetLastError.rsp
@@ -744,10 +744,16 @@ DialogBoxIndirectParamA
 DialogBoxIndirectParamW
 DialogBoxParamA
 DialogBoxParamW
+DiInstallDevice
+DiInstallDriverA
+DiInstallDriverW
+DiRollbackDriver
 DisableThreadLibraryCalls
 DisconnectNamedPipe
 DiShowUpdateDevice
 DiUninstallDevice
+DiUninstallDriverA
+DiUninstallDriverW
 DlgDirListComboBoxA
 DlgDirListComboBoxW
 DlgDirSelectComboBoxExA
@@ -2994,6 +3000,8 @@ UnregisterWait
 UnregisterWaitEx
 UnregisterWaitUntilOOBECompleted
 UpdateDebugInfoFile
+UpdateDriverForPlugAndPlayDevicesA
+UpdateDriverForPlugAndPlayDevicesW
 UpdateLayeredWindow
 UpdateProcThreadAttribute
 UpdateResourceA

--- a/scripts/BaselineWinmd/Windows.Win32.winmd
+++ b/scripts/BaselineWinmd/Windows.Win32.winmd
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a68ca9d5fe3613a6f9652caf2f8b5c64a5db6ef9adfbd368157e9f8a673be152
+oid sha256:ea570064e7b75f826200e69527235d3a7cfaa04ba4fd5db715c94d06b7bd92ae
 size 16123392


### PR DESCRIPTION
Marks additional Di* APIs with SetLastError=true per docs.

Fixes: #826

Metadata diff:
```
Windows.Win32.Devices.DeviceAndDriverInstallation.Apis.UpdateDriverForPlugAndPlayDevicesA : [DllImport(newdev,ExactSpelling=True,PreserveSig=False),SupportedOSPlatform(windows5.0)] => [DllImport(newdev,ExactSpelling=True,PreserveSig=False,SetLastError=True),SupportedOSPlatform(windows5.0)]
Windows.Win32.Devices.DeviceAndDriverInstallation.Apis.UpdateDriverForPlugAndPlayDevicesW : [DllImport(newdev,ExactSpelling=True,PreserveSig=False),SupportedOSPlatform(windows5.0)] => [DllImport(newdev,ExactSpelling=True,PreserveSig=False,SetLastError=True),SupportedOSPlatform(windows5.0)]
Windows.Win32.Devices.DeviceAndDriverInstallation.Apis.DiInstallDevice : [DllImport(newdev,ExactSpelling=True,PreserveSig=False),SupportedOSPlatform(windows6.0.6000)] => [DllImport(newdev,ExactSpelling=True,PreserveSig=False,SetLastError=True),SupportedOSPlatform(windows6.0.6000)]
Windows.Win32.Devices.DeviceAndDriverInstallation.Apis.DiInstallDriverW : [DllImport(newdev,ExactSpelling=True,PreserveSig=False),SupportedOSPlatform(windows6.0.6000)] => [DllImport(newdev,ExactSpelling=True,PreserveSig=False,SetLastError=True),SupportedOSPlatform(windows6.0.6000)]
Windows.Win32.Devices.DeviceAndDriverInstallation.Apis.DiInstallDriverA : [DllImport(newdev,ExactSpelling=True,PreserveSig=False),SupportedOSPlatform(windows6.0.6000)] => [DllImport(newdev,ExactSpelling=True,PreserveSig=False,SetLastError=True),SupportedOSPlatform(windows6.0.6000)]
Windows.Win32.Devices.DeviceAndDriverInstallation.Apis.DiUninstallDriverW : [DllImport(newdev,ExactSpelling=True,PreserveSig=False),SupportedOSPlatform(windows10.0.10240)] => [DllImport(newdev,ExactSpelling=True,PreserveSig=False,SetLastError=True),SupportedOSPlatform(windows10.0.10240)]
Windows.Win32.Devices.DeviceAndDriverInstallation.Apis.DiUninstallDriverA : [DllImport(newdev,ExactSpelling=True,PreserveSig=False)] => [DllImport(newdev,ExactSpelling=True,PreserveSig=False,SetLastError=True)]
Windows.Win32.Devices.DeviceAndDriverInstallation.Apis.DiRollbackDriver : [DllImport(newdev,ExactSpelling=True,PreserveSig=False),SupportedOSPlatform(windows6.0.6000)] => [DllImport(newdev,ExactSpelling=True,PreserveSig=False,SetLastError=True),SupportedOSPlatform(windows6.0.6000)]
```