### PR TITLE
Create scoped enums for PFD constants

### DIFF
--- a/generation/WinSDK/enums.json
+++ b/generation/WinSDK/enums.json
@@ -29566,5 +29566,143 @@
         "field": "Parity"
       }
     ]
+  },
+  {
+    "name": "PFD_PIXEL_TYPE",
+    "flags": false,
+    "type": "sbyte",
+    "members": [
+      {
+        "name": "PFD_TYPE_RGBA",
+        "value": 0
+      },
+      {
+        "name": "PFD_TYPE_COLORINDEX",
+        "value": 1
+      }
+    ],
+    "uses": [
+      {
+        "struct": "PIXELFORMATDESCRIPTOR",
+        "field": "iPixelType"
+      },
+      {
+        "method": "DescribePixelFormat",
+        "parameter": "iPixelFormat"
+      }
+    ]
+  },
+  {
+    "name": "PFD_LAYER_TYPE",
+    "flags": false,
+    "type": "sbyte",
+    "members": [
+      {
+        "name": "PFD_UNDERLAY_PLANE",
+        "value": -1
+      },
+      {
+        "name": "PFD_MAIN_PLANE",
+        "value": 0
+      },
+      {
+        "name": "PFD_OVERLAY_PLANE",
+        "value": 1
+      }
+    ],
+    "uses": [
+      {
+        "struct": "PIXELFORMATDESCRIPTOR",
+        "field": "iLayerType"
+      }
+    ]
+  },
+  {
+    "name": "PFD_FLAGS",
+    "flags": true,
+    "members": [
+      {
+        "name": "PFD_DOUBLEBUFFER",
+        "value": 1
+      },
+      {
+        "name": "PFD_STEREO",
+        "value": 2
+      },
+      {
+        "name": "PFD_DRAW_TO_WINDOW",
+        "value": 4
+      },
+      {
+        "name": "PFD_DRAW_TO_BITMAP",
+        "value": 8
+      },
+      {
+        "name": "PFD_SUPPORT_GDI",
+        "value": "0x10"
+      },
+      {
+        "name": "PFD_SUPPORT_OPENGL",
+        "value": "0x20"
+      },
+      {
+        "name": "PFD_GENERIC_FORMAT",
+        "value": "0x40"
+      },
+      {
+        "name": "PFD_NEED_PALETTE",
+        "value": "0x80"
+      },
+      {
+        "name": "PFD_NEED_SYSTEM_PALETTE",
+        "value": "0x100"
+      },
+      {
+        "name": "PFD_SWAP_EXCHANGE",
+        "value": "0x200"
+      },
+      {
+        "name": "PFD_SWAP_COPY",
+        "value": "0x400"
+      },
+      {
+        "name": "PFD_SWAP_LAYER_BUFFERS",
+        "value": "0x800"
+      },
+      {
+        "name": "PFD_GENERIC_ACCELERATED",
+        "value": "0x1000"
+      },
+      {
+        "name": "PFD_SUPPORT_DIRECTDRAW",
+        "value": "0x2000"
+      },
+      {
+        "name": "PFD_DIRECT3D_ACCELERATED",
+        "value": "0x4000"
+      },
+      {
+        "name": "PFD_SUPPORT_COMPOSITION",
+        "value": "0x8000"
+      },
+      {
+        "name": "PFD_DEPTH_DONTCARE",
+        "value": "0x20000000"
+      },
+      {
+        "name": "PFD_DOUBLEBUFFER_DONTCARE",
+        "value": "0x40000000"
+      },
+      {
+        "name": "PFD_STEREO_DONTCARE",
+        "value": "0x80000000"
+      }
+    ],
+    "uses": [
+      {
+        "struct": "PIXELFORMATDESCRIPTOR",
+        "field": "dwFlags"
+      }
+    ]
   }
 ]

--- a/scripts/BaselineWinmd/Windows.Win32.winmd
+++ b/scripts/BaselineWinmd/Windows.Win32.winmd
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a68ca9d5fe3613a6f9652caf2f8b5c64a5db6ef9adfbd368157e9f8a673be152
-size 16123392
+oid sha256:5394a5d9f359d39404b3bc7b4746abfd7e8175e3389b82c72bca3067f8ee4c1e
+size 16123904


### PR DESCRIPTION
Creates scoped enum for `PFD_` constants (used by `PIXELFORMATDESCRIPTOR` and `DescribePixelFormat`).

Fixes #825.