### PR TITLE
Set CoRegisterClassObject flag param type

### DIFF
--- a/generation/WinSDK/emitter.settings.rsp
+++ b/generation/WinSDK/emitter.settings.rsp
@@ -447,6 +447,7 @@ CoCreateInstance::dwClsContext=CLSCTX
 CoCreateInstanceEx::dwClsCtx=CLSCTX
 CoCreateInstanceFromApp::dwClsCtx=CLSCTX
 CoRegisterClassObject::dwClsContext=CLSCTX
+CoRegisterClassObject::flags=REGCLS
 CoGetClassObject::dwClsContext=CLSCTX
 CoGetClassObjectFromURL::dwClsContext=CLSCTX
 CoGetInstanceFromFile::dwClsCtx=CLSCTX

--- a/scripts/BaselineWinmd/Windows.Win32.winmd
+++ b/scripts/BaselineWinmd/Windows.Win32.winmd
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a68ca9d5fe3613a6f9652caf2f8b5c64a5db6ef9adfbd368157e9f8a673be152
+oid sha256:a4ae5c64a6996308b4c3fb01b43aad2e543b0a37a5e2d59f75200feab68d664e
 size 16123392


### PR DESCRIPTION
Sets `CoRegisterClassObject` `flags` param to type `REGCLS`

Fixes #823

Metadata diff
```
Windows.Win32.System.Com.Apis.CoRegisterClassObject : flags...UInt32 => REGCLS
```