### PR TITLE
Add missing CoreWindow APIs to Windows.Win32.System.WinRT

### DIFF
--- a/generation/WinSDK/Partitions/WinRT/main.cpp
+++ b/generation/WinSDK/Partitions/WinRT/main.cpp
@@ -41,3 +41,4 @@
 #include <systemmediatransportcontrolsinterop.h>
 #include <sharewindowcommandsourceinterop.h>
 #include <messagedispatcherapi.h>
+#include <CoreWindow.h>

--- a/generation/WinSDK/Partitions/WinRT/settings.rsp
+++ b/generation/WinSDK/Partitions/WinRT/settings.rsp
@@ -27,6 +27,7 @@ ID2D1Factory
 <IncludeRoot>/um/UserConsentVerifierInterop.h
 <IncludeRoot>/um/WebAuthenticationCoreManagerInterop.h
 <IncludeRoot>/winrt/activation.h
+<IncludeRoot>/winrt/corewindow.h
 <IncludeRoot>/winrt/hstring.h
 <IncludeRoot>/winrt/inspectable.h
 <IncludeRoot>/winrt/memorybuffer.h

--- a/scripts/BaselineWinmd/Windows.Win32.winmd
+++ b/scripts/BaselineWinmd/Windows.Win32.winmd
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a68ca9d5fe3613a6f9652caf2f8b5c64a5db6ef9adfbd368157e9f8a673be152
-size 16123392
+oid sha256:2d49f4060dc36df9fb767ea3ac2e6bb5d056686fb2d3d3b0184e66ca96ed56de
+size 16124928


### PR DESCRIPTION
Adds missing CoreWindow interfaces, APIs to metadata (corewindow.h).

Fixes #830

Metadata diff
```
Windows.Win32.System.WinRT.ICoreWindowInterop not found in 1st winmd
Windows.Win32.System.WinRT.ICoreInputInterop not found in 1st winmd
Windows.Win32.System.WinRT.ICoreWindowComponentInterop not found in 1st winmd
Windows.Win32.System.WinRT.ICoreWindowAdapterInterop not found in 1st winmd
Windows.Win32.System.WinRT.Apis.CreateControlInput not found in 1st winmd
Windows.Win32.System.WinRT.Apis.CreateControlInputEx not found in 1st winmd
```