### PR TITLE
Add InvalidHandleAttribute to HINSTANCE

### DIFF
--- a/generation/WinSDK/autoTypes.json
+++ b/generation/WinSDK/autoTypes.json
@@ -26,7 +26,8 @@
     "Namespace": "Windows.Win32.Foundation",
     "Name": "HINSTANCE",
     "ValueType": "DECLARE_HANDLE",
-    "CloseApi": "FreeLibrary"
+    "CloseApi": "FreeLibrary",
+    "InvalidHandleValues": [ 0 ]
   },
   {
     "Namespace": "Windows.Win32.Foundation",

--- a/scripts/BaselineWinmd/Windows.Win32.winmd
+++ b/scripts/BaselineWinmd/Windows.Win32.winmd
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:64ee5654ad1232c8ed52c00d6f06db8465e1933e7d8a68ecbfbcc517c02dd2db
+oid sha256:6483dddc814ba9c775c5aa4798bf9d6dfbe8b650c3d601b9f03dd3c7efef8118
 size 16089600


### PR DESCRIPTION
Adds `InvalidHandleValueAttribute` to HINSTANCE.

Did not also specify `-1` due to `#define HINST_COMMCTRL ((HINSTANCE)-1)` making `tagTBADDBITMAP` usage awkward.

Metadata diff:
```
Windows.Win32.Foundation.HINSTANCE : [RAIIFree(FreeLibrary),NativeTypedef] => [RAIIFree(FreeLibrary),InvalidHandleValue(0),NativeTypedef]
```