### PR TITLE
Annotate JOB_OBJECT_CPU_RATE_CONTROL as flags

### DIFF
--- a/generation/WinSDK/enums.json
+++ b/generation/WinSDK/enums.json
@@ -20612,6 +20612,7 @@
   },
   {
     "name": "JOB_OBJECT_CPU_RATE_CONTROL",
+    "flags": true,
     "namespace": "Windows.Win32.System.JobObjects",
     "members": [
       {

--- a/scripts/BaselineWinmd/Windows.Win32.winmd
+++ b/scripts/BaselineWinmd/Windows.Win32.winmd
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6483dddc814ba9c775c5aa4798bf9d6dfbe8b650c3d601b9f03dd3c7efef8118
+oid sha256:eac3aca32b7afb75d20c2475b3ce1defeb3b542f78fb2340b2cbb5b9bbb0627b
 size 16089600


### PR DESCRIPTION
Adds `[Flags]` to `JOB_OBJECT_CPU_RATE_CONTROL`.

Fixes: #873

Metadata diff:
```
Assembly (informational only) : [AssemblyVersion(22.0.3.46746)] => [AssemblyVersion(22.0.3.15463)]
Windows.Win32.System.JobObjects.JOB_OBJECT_CPU_RATE_CONTROL :  => [Flags]
```