### PR TITLE
Change MOUSEINPUT mouseData data type

### DIFF
--- a/generation/WinSDK/emitter.settings.rsp
+++ b/generation/WinSDK/emitter.settings.rsp
@@ -454,6 +454,7 @@ CoGetInstanceFromFile::dwClsCtx=CLSCTX
 CoGetInstanceFromIStorage::dwClsCtx=CLSCTX
 mouse_event::dx=int
 mouse_event::dy=int
+MOUSEINPUT::mouseData=int
 IMAGE_OPTIONAL_HEADER32::LoaderFlags=[Obsolete]
 IMAGE_OPTIONAL_HEADER64::LoaderFlags=[Obsolete]
 MsiGetFeatureValidStates::lpInstallStates=INSTALLSTATE

--- a/scripts/BaselineWinmd/Windows.Win32.winmd
+++ b/scripts/BaselineWinmd/Windows.Win32.winmd
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6483dddc814ba9c775c5aa4798bf9d6dfbe8b650c3d601b9f03dd3c7efef8118
+oid sha256:c7825ce5cdaba67f96d0ecb2ba99b507dd12cac610066fd3357b4011fe5f4100
 size 16089600


### PR DESCRIPTION
Changes `MOUSEINPUT::mouseData` data type from uint to int to support [documented `MOUSEEVENTF_WHEEL` semantics](https://docs.microsoft.com/en-us/windows/win32/api/winuser/ns-winuser-mouseinput#:~:text=a%20negative%20value%20indicates%20that%20the%20wheel%20was%20rotated%20backward%2C%20toward%20the%20user).

Fixes: #876

Metadata diff:
```
Assembly (informational only) : [AssemblyVersion(22.0.3.46746)] => [AssemblyVersion(22.0.3.15463)]
Windows.Win32.UI.Input.KeyboardAndMouse.MOUSEINPUT.mouseData...System.UInt32 => System.Int32
```