### PR TITLE
Change return type for several aclapi functions

### DIFF
--- a/generation/WinSDK/emitter.settings.rsp
+++ b/generation/WinSDK/emitter.settings.rsp
@@ -863,3 +863,6 @@ IAudioClient::GetService::ppv=[ComOutPtr]
 IDataObject::GetCanonicalFormatEtc=[PreserveSig]
 IEnumExplorerCommand::Next=[PreserveSig]
 INetCfgComponentUpperEdge::AddInterfacesToAdapter::pAdapter=[-NativeArrayInfo]
+GetNamedSecurityInfoA::return=WIN32_ERROR
+GetNamedSecurityInfoW::return=WIN32_ERROR
+GetSecurityInfo::return=WIN32_ERROR

--- a/scripts/BaselineWinmd/Windows.Win32.winmd
+++ b/scripts/BaselineWinmd/Windows.Win32.winmd
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6483dddc814ba9c775c5aa4798bf9d6dfbe8b650c3d601b9f03dd3c7efef8118
+oid sha256:f6ff5bb822ce5aefdc64c9373e26fe17343344e81f870aa6f863641adacad5ad
 size 16089600


### PR DESCRIPTION
Improves return type of several ACLAPI functions.

Fixes: #884

Metadata diff:
```
Assembly (informational only) : [AssemblyVersion(22.0.3.46746)] => [AssemblyVersion(22.0.3.15463)]
Windows.Win32.Security.Authorization.Apis.GetNamedSecurityInfoA : return...UInt32 => WIN32_ERROR
Windows.Win32.Security.Authorization.Apis.GetNamedSecurityInfoW : return...UInt32 => WIN32_ERROR
Windows.Win32.Security.Authorization.Apis.GetSecurityInfo : return...UInt32 => WIN32_ERROR
```