### PR TITLE
Combine send/recv flags into new SEND_RECV_FLAGS enumeration

### DIFF
--- a/generation/WinSDK/enums.json
+++ b/generation/WinSDK/enums.json
@@ -15871,18 +15871,38 @@
     ]
   },
   {
-    "name": "SEND_FLAGS",
+    "name": "SEND_RECV_FLAGS",
+    "type": "int",
+    "flags": true,
     "members": [
       {
-        "name": "MSG_DONTROUTE"
+        "name": "MSG_OOB",
+        "value": 1
       },
       {
-        "name": "MSG_OOB"
+        "name": "MSG_PEEK",
+        "value": 2
+      },
+      {
+        "name": "MSG_DONTROUTE",
+        "value": 4
+      },
+      {
+        "name": "MSG_WAITALL",
+        "value": 8
+      },
+      {
+        "name": "MSG_PUSH_IMMEDIATE",
+        "value": 32
       }
     ],
     "uses": [
       {
         "method": "send",
+        "parameter": "flags"
+      },
+      {
+        "method": "recv",
         "parameter": "flags"
       }
     ]

--- a/scripts/BaselineWinmd/Windows.Win32.winmd
+++ b/scripts/BaselineWinmd/Windows.Win32.winmd
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6483dddc814ba9c775c5aa4798bf9d6dfbe8b650c3d601b9f03dd3c7efef8118
+oid sha256:55934d3e8ba73a9f32168f72010061b9f881069ad22b81a17e3817b67fc0503f
 size 16089600


### PR DESCRIPTION
Combines send/recv flags into new `SEND_RECV_FLAGS` enumeration of integers and associates with send/recv functions.

Fixes: #849

Metadata diff:
```
Windows.Win32.Networking.WinSock.SEND_FLAGS not found in 2nd winmd
Windows.Win32.Networking.WinSock.SEND_RECV_FLAGS not found in 1st winmd
Windows.Win32.Networking.WinSock.Apis.MSG_PEEK not found in 2nd winmd
Windows.Win32.Networking.WinSock.Apis.MSG_WAITALL not found in 2nd winmd
Windows.Win32.Networking.WinSock.Apis.MSG_PUSH_IMMEDIATE not found in 2nd winmd
Windows.Win32.Networking.WinSock.Apis.recv : flags...Int32 => SEND_RECV_FLAGS
Windows.Win32.Networking.WinSock.Apis.send : flags...SEND_FLAGS => SEND_RECV_FLAGS
```

@mikebattista Can you double-check this satisfies what was discussed in #849? Thanks!