### PR TITLE
Provide manual definition of HSTRING_HEADER

### DIFF
--- a/generation/WinSDK/manual/WinRT.cs
+++ b/generation/WinSDK/manual/WinRT.cs
@@ -9,4 +9,13 @@ namespace Windows.Win32.System.WinRT
     {
         public long value;
     }
+
+    public struct HSTRING_HEADER
+    {
+        public uint flags;
+        public uint length;
+        public uint padding1;
+        public uint padding2;
+        public IntPtr data;
+    }
 }

--- a/generation/WinSDK/scraper.settings.rsp
+++ b/generation/WinSDK/scraper.settings.rsp
@@ -71,6 +71,7 @@ __RPCPROXY_H_VERSION__
 _DISPATCHER_CONTEXT_ARM64
 tagMONITORINFOEXA
 tagMONITORINFOEXW
+HSTRING_HEADER
 --remap
 ABI::Windows::Foundation::IActivatableClassRegistration=IActivatableClassRegistration
 adpcmcoef_tag=ADPCMCOEFSET

--- a/scripts/BaselineWinmd/Windows.Win32.winmd
+++ b/scripts/BaselineWinmd/Windows.Win32.winmd
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6483dddc814ba9c775c5aa4798bf9d6dfbe8b650c3d601b9f03dd3c7efef8118
+oid sha256:1feb38235e3a93633511ee6b4c0147cb2dec208ac630107f0f1a43018d2113ac
 size 16089600


### PR DESCRIPTION
Adds a manual definition of `HSTRING_HEADER` to clean up the awkward union.

Fixes: #886 

Before:
```csharp
public struct HSTRING_HEADER
{
  [StructLayout(LayoutKind.Explicit)]
  public struct _Reserved_e__Union
  {
    [FieldOffset(0)]
    public unsafe void* Reserved1;
    [FieldOffset(0)]
    public CHAR[] Reserved2;
  }
  public _Reserved_e__Union Reserved;
}
```

After:
```csharp
public struct HSTRING_HEADER
{
  public uint flags;
  public uint length;
  public uint padding1;
  public uint padding2;
  public IntPtr data;
}
```

Metadata diff:
```
Windows.Win32.System.WinRT.HSTRING_HEADER.Reserved not found in 2nd winmd
Windows.Win32.System.WinRT.HSTRING_HEADER.flags not found in 1st winmd
Windows.Win32.System.WinRT.HSTRING_HEADER.length not found in 1st winmd
Windows.Win32.System.WinRT.HSTRING_HEADER.padding1 not found in 1st winmd
Windows.Win32.System.WinRT.HSTRING_HEADER.padding2 not found in 1st winmd
Windows.Win32.System.WinRT.HSTRING_HEADER.data not found in 1st winmd
Windows.Win32.System.WinRT.HSTRING_HEADER._Reserved_e__Union not found in 2nd winmd
```