### PR TITLE
Adjust regex for MAKEINTRESOURCE[AW] usage

### DIFF
--- a/scripts/BaselineWinmd/Windows.Win32.winmd
+++ b/scripts/BaselineWinmd/Windows.Win32.winmd
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a83fe9b345e8929d7f295a9d5e603391e40254fee85c0c3fad49ff70d526aa02
+oid sha256:2b8814d5e8d7df84eb0a281c3b55cff3b58cccfb3c80aacd33694011341cfdf9
 size 16089600

--- a/sources/MetadataUtils/ConstantsScraper.cs
+++ b/sources/MetadataUtils/ConstantsScraper.cs
@@ -33,7 +33,7 @@ namespace MetadataUtils
 
             private static readonly Regex DefineConstantRegex =
                 new Regex(
-                    @"^((_HRESULT_TYPEDEF_|_NDIS_ERROR_TYPEDEF_)\(((?:0x)?[\da-f]+L?)\)|(\(HRESULT\)((?:0x)?[\da-f]+L?))|(-?\d+\.\d+(?:e\+\d+)?f?)|((?:0x[\da-f]+|\-?\d+)(?:UL|L)?)|((\d+)\s*(<<\s*\d+))|(MAKEINTRESOURCE\(\s*(\-?\d+)\s*\))|(\(HWND\)(-?\d+))|([a-z0-9_]+\s*\+\s*(\d+|0x[0-de-f]+))|(\(NTSTATUS\)((?:0x)?[\da-f]+L?))|(\s*\(DWORD\)\s*\(?\s*-1(L|\b)\s*\)?)|(\(BCRYPT_ALG_HANDLE\)\s*((?:0x)?[\da-f]+L?))|([a-z0-9_]+))$", RegexOptions.IgnoreCase);
+                    @"^((_HRESULT_TYPEDEF_|_NDIS_ERROR_TYPEDEF_)\(((?:0x)?[\da-f]+L?)\)|(\(HRESULT\)((?:0x)?[\da-f]+L?))|(-?\d+\.\d+(?:e\+\d+)?f?)|((?:0x[\da-f]+|\-?\d+)(?:UL|L)?)|((\d+)\s*(<<\s*\d+))|(MAKEINTRESOURCE[AW]{0,1}\(\s*(\-?\d+)\s*\))|(\(HWND\)(-?\d+))|([a-z0-9_]+\s*\+\s*(\d+|0x[0-de-f]+))|(\(NTSTATUS\)((?:0x)?[\da-f]+L?))|(\s*\(DWORD\)\s*\(?\s*-1(L|\b)\s*\)?)|(\(BCRYPT_ALG_HANDLE\)\s*((?:0x)?[\da-f]+L?))|([a-z0-9_]+))$", RegexOptions.IgnoreCase);
 
             private static readonly Regex DefineGuidConstRegex =
                 new Regex(

--- a/sources/MetadataUtils/ConstantsScraper.cs
+++ b/sources/MetadataUtils/ConstantsScraper.cs
@@ -681,10 +681,17 @@ namespace MetadataUtils
                                 string part2 = match.Groups[10].Value;
                                 valueText = part1 + part2;
                             }
-                            // MAKEINTRESOURCE(-4)
+                            // MAKEINTRESOURCE(-4), MAKEINTRESOURCEA(-1), MAKEINTRESOURCEW(42)
                             else if (!string.IsNullOrEmpty(match.Groups[11].Value))
                             {
-                                nativeTypeName = "LPCWSTR";
+                                if (match.Groups[11].Value.StartsWith("MAKEINTRESOURCEA"))
+                                {
+                                    nativeTypeName = "LPCSTR";
+                                }
+                                else
+                                {
+                                    nativeTypeName = "LPCWSTR";
+                                }
                                 valueText = match.Groups[12].Value;
                                 this.AddConstantInteger(currentNamespace, nativeTypeName, name, valueText);
                                 continue;


### PR DESCRIPTION
Tweaks the regular expression looking for `MAKEINTRESOURCE` matches to also find `A` and `W` variants.

Fixes: #968

Example:
```cpp
#define TD_WARNING_ICON         MAKEINTRESOURCEW(-1)
#define TD_ERROR_ICON           MAKEINTRESOURCEW(-2)
#define TD_INFORMATION_ICON     MAKEINTRESOURCEW(-3)
#define TD_SHIELD_ICON          MAKEINTRESOURCEW(-4)
```

Metadata diff:
```
Windows.Win32.UI.Controls.Apis.TD_WARNING_ICON not found in 1st winmd
Windows.Win32.UI.Controls.Apis.TD_ERROR_ICON not found in 1st winmd
Windows.Win32.UI.Controls.Apis.TD_INFORMATION_ICON not found in 1st winmd
Windows.Win32.UI.Controls.Apis.TD_SHIELD_ICON not found in 1st winmd
```