### PR TITLE
Add MAXIMUM_REPARSE_DATA_BUFFER_SIZE constant

### DIFF
--- a/generation/WinSDK/manual/FileSystem.cs
+++ b/generation/WinSDK/manual/FileSystem.cs
@@ -122,4 +122,9 @@ namespace Windows.Win32.Storage.FileSystem
 
         FILE_GENERIC_EXECUTE = (STANDARD_RIGHTS_EXECUTE | FILE_READ_ATTRIBUTES | FILE_EXECUTE | SYNCHRONIZE)
     }
+
+    public static unsafe partial class Apis
+    {
+        public const uint MAXIMUM_REPARSE_DATA_BUFFER_SIZE = 16 * 1024;
+    }
 }

--- a/scripts/BaselineWinmd/Windows.Win32.winmd
+++ b/scripts/BaselineWinmd/Windows.Win32.winmd
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a83fe9b345e8929d7f295a9d5e603391e40254fee85c0c3fad49ff70d526aa02
+oid sha256:4449cf1ba62497c00349193d9b0d2078e268de1744c9c8eaa8a3b2fb69661524
 size 16089600


### PR DESCRIPTION
Adds missing `MAXIMUM_REPARSE_DATA_BUFFER_SIZE` constant manually for now. Longer term, it'd be nice if the constant scraper supported some basic expression evaluation.

Fixes: #966 