### PR TITLE
Force rapid discovery of missing VS required components for the build

### DIFF
--- a/DoAll.ps1
+++ b/DoAll.ps1
@@ -17,6 +17,9 @@ param
     $arch = "crossarch"
 )
 
+# Run this script so it throws if VS isn't installed with the required workloads.
+& "$PSScriptRoot\scripts\Get-VSPath.ps1" | Out-Null
+
 if (!$SkipInstallTools.IsPresent)
 {
     . .\scripts\CommonUtils.ps1

--- a/scripts/Get-RequiredWorkloads.ps1
+++ b/scripts/Get-RequiredWorkloads.ps1
@@ -2,5 +2,5 @@
 
 # Please keep this list sorted.
 
-'Microsoft.VisualStudio.Component.VC.Tools.x86.x64'
 'Microsoft.VisualStudio.Component.VC.Tools.ARM64'
+'Microsoft.VisualStudio.Component.VC.Tools.x86.x64'


### PR DESCRIPTION
Without this change, DoAll.ps1 could execute a bunch of work and ultimately fail to build a vcxproj with a misleading error message.