### PR TITLE
Fix emission of Optional attribute on SAL annotated items

### DIFF
--- a/scripts/BaselineWinmd/Windows.Win32.winmd
+++ b/scripts/BaselineWinmd/Windows.Win32.winmd
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d8c1bb923a1ac24b3423af35845111403641835c1485022e227103f3b8c232c2
+oid sha256:6b1ff48cbd2aaca2fbe8fca013b388c0bdfa63a14cd9cb0620489af2da6a8308
 size 16089600

--- a/sources/ClangSharpSourceToWinmd/MetadataSyntaxTreeCleaner.cs
+++ b/sources/ClangSharpSourceToWinmd/MetadataSyntaxTreeCleaner.cs
@@ -838,12 +838,11 @@ namespace ClangSharpSourceToWinmd
                             isReserved = true;
                             continue;
                         }
-                    }
-
-                    if (salAttr.Name == "SAL_null" && salAttr.P1 == "__maybe")
-                    {
-                        isOpt = true;
-                        continue;
+                        else if (salAttr.P1.Contains("_opt"))
+                        {
+                            isOpt = true;
+                            continue;
+                        }
                     }
 
                     if (salAttr.Name == "SAL_retval")


### PR DESCRIPTION
Corrects the incorrect emission of `[Optional]` attributes on items marked as SAL _maybe null_. Instead, we now look for SAL _optional_ markings.

Fixes: #1005 

Metadata diff (too large for PR):
https://gist.githubusercontent.com/riverar/797554a9b031279a6c6fabeab0183824/raw/e4e9cbb9889515fc3beffd622537027cbbb99691/metadata-diff.txt