### PR TITLE
Compensate for _Old_ intrinsic during SAL writableTo/readableTo capture

### DIFF
--- a/scripts/BaselineWinmd/Windows.Win32.winmd
+++ b/scripts/BaselineWinmd/Windows.Win32.winmd
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d8c1bb923a1ac24b3423af35845111403641835c1485022e227103f3b8c232c2
+oid sha256:04b462fd2e96d6f4a3fedb2dd403fe61f4fae763b0ef1510b3a2693d7c7d98c3
 size 16089600

--- a/sources/ClangSharpSourceToWinmd/MetadataSyntaxTreeCleaner.cs
+++ b/sources/ClangSharpSourceToWinmd/MetadataSyntaxTreeCleaner.cs
@@ -22,7 +22,7 @@ namespace ClangSharpSourceToWinmd
 
         private class TreeRewriter : CSharpSyntaxRewriter
         {
-            private static readonly Regex ElementCountRegex = new Regex(@"(?:elementCount|byteCount)\(([^\)]+)\)");
+            private static readonly Regex ElementCountRegex = new Regex(@"(?:elementCount|byteCount)\((?:_Old_\()?([^\)]+)\)+");
             private static readonly Regex IsRegex = new Regex(@"[^\w::]");
 
             private HashSet<SyntaxNode> nodesWithMarshalAs = new HashSet<SyntaxNode>();


### PR DESCRIPTION
Extends regular expression to correctly capture `SAL_readableTo` / `SAL_writeableTo` buffer size information if `_Old_` intrinsic is in use (e.g. `Name=SAL_readableTo; p1=byteCount(_Old_(cbKeyObject))`).

Fixes: #1010

Metadata diff:
```
Windows.Win32.System.Com.Urlmon.IInternetHostSecurityManager.ProcessUrlAction : pPolicy : [Out] => [Out,NativeArrayInfo(CountParamIndex=2)]
Windows.Win32.Graphics.Dxgi.IDXGIDevice2.ReclaimResources : pDiscarded : [Optional,Out] => [Optional,Out,NativeArrayInfo(CountParamIndex=0)]
Windows.Win32.Graphics.Dxgi.IDXGIDevice4.ReclaimResources1 : pResults : [Out] => [Out,NativeArrayInfo(CountParamIndex=0)]
Windows.Win32.Security.Cryptography.Apis.BCryptGenerateSymmetricKey : pbKeyObject : [Optional,Out] => [Optional,Out,MemorySize(BytesParamIndex=3)]
Windows.Win32.Security.Cryptography.Apis.BCryptImportKey : pbKeyObject : [Optional,Out] => [Optional,Out,MemorySize(BytesParamIndex=5)]
Windows.Win32.Security.Cryptography.Apis.BCryptDuplicateKey : pbKeyObject : [Optional,Out] => [Optional,Out,MemorySize(BytesParamIndex=3)]
Windows.Win32.Security.Cryptography.Apis.BCryptCreateHash : pbHashObject : [Optional,Out] => [Optional,Out,MemorySize(BytesParamIndex=3)]
Windows.Win32.Security.Cryptography.Apis.BCryptFinishHash : pbOutput : [Out] => [Out,MemorySize(BytesParamIndex=2)]
Windows.Win32.Security.Cryptography.Apis.BCryptCreateMultiHash : pbHashObject : [Optional,Out] => [Optional,Out,MemorySize(BytesParamIndex=4)]
Windows.Win32.Security.Cryptography.Apis.BCryptDuplicateHash : pbHashObject : [Optional,Out] => [Optional,Out,MemorySize(BytesParamIndex=3)]
Windows.Win32.Security.Cryptography.Apis.BCryptHash : pbOutput : [Out] => [Out,MemorySize(BytesParamIndex=6)]
Windows.Win32.Security.Cryptography.Apis.CertGetIntendedKeyUsage : pbKeyUsage : [Out] => [Out,MemorySize(BytesParamIndex=3)]
Windows.Win32.UI.Shell.Apis.IStream_Read : pv : [Out] => [Out,MemorySize(BytesParamIndex=2)]
Windows.Win32.Globalization.Apis.ScriptLayout : piVisualToLogical : [Optional,Out] => [Optional,Out,NativeArrayInfo(CountParamIndex=0)]
Windows.Win32.Globalization.Apis.ScriptLayout : piLogicalToVisual : [Optional,Out] => [Optional,Out,NativeArrayInfo(CountParamIndex=0)]
Windows.Win32.Globalization.Apis.ScriptShape : pwLogClust : [Out] => [Out,NativeArrayInfo(CountParamIndex=3)]
Windows.Win32.Globalization.Apis.ScriptPlace : piAdvance : [Out] => [Out,NativeArrayInfo(CountParamIndex=3)]
Windows.Win32.Globalization.Apis.ScriptPlace : pGoffset : [Optional,Out] => [Optional,Out,NativeArrayInfo(CountParamIndex=3)]
Windows.Win32.Globalization.Apis.ScriptJustify : piJustify : [Out] => [Out,NativeArrayInfo(CountParamIndex=2)]
Windows.Win32.Globalization.Apis.ScriptBreak : psla : [Out] => [Out,NativeArrayInfo(CountParamIndex=1)]
Windows.Win32.Globalization.Apis.ScriptApplyLogicalWidth : piJustify : [Out] => [Out,NativeArrayInfo(CountParamIndex=2)]
Windows.Win32.Globalization.Apis.ScriptShapeOpenType : pwLogClust : [Out] => [Out,NativeArrayInfo(CountParamIndex=9)]
Windows.Win32.Globalization.Apis.ScriptShapeOpenType : pCharProps : [Out] => [Out,NativeArrayInfo(CountParamIndex=9)]
Windows.Win32.Globalization.Apis.ScriptPlaceOpenType : piAdvance : [Out] => [Out,NativeArrayInfo(CountParamIndex=14)]
Windows.Win32.Globalization.Apis.ScriptPlaceOpenType : pGoffset : [Out] => [Out,NativeArrayInfo(CountParamIndex=14)]
Windows.Win32.NetworkManagement.P2P.Apis.DrtGetEventData : pEventData : [Out] => [Out,MemorySize(BytesParamIndex=1)]
Windows.Win32.NetworkManagement.P2P.Apis.DrtGetSearchResult : pSearchResult : [Out] => [Out,MemorySize(BytesParamIndex=1)]
Windows.Win32.NetworkManagement.P2P.Apis.DrtGetSearchPath : pSearchPath : [Out] => [Out,MemorySize(BytesParamIndex=1)]
Windows.Win32.NetworkManagement.P2P.Apis.DrtGetInstanceName : pwzDrtInstanceName : [Out] => [Out,MemorySize(BytesParamIndex=1)]
Windows.Win32.UI.Shell.PropertiesSystem.Apis.SHPropStgReadMultiple : rgvar : [Out] => [Out,NativeArrayInfo(CountParamIndex=2)]
Windows.Win32.System.HostComputeNetwork.Apis.HcnEnumerateGuestNetworkPortReservations : PortEntries : [Out] => [Out,MemorySize(BytesParamIndex=0)]
```