### PR TITLE
Don't let the #define DeleteFile mess up field and param names

### DIFF
--- a/generation/WinSDK/Partitions/WinProg/settings.rsp
+++ b/generation/WinSDK/Partitions/WinProg/settings.rsp
@@ -8,6 +8,7 @@ RtlRaiseException
 RtlPcToFileHeader
 RtlCompareMemory
 UiaRect
+_FILE_DISPOSITION_INFO
 _TEB
 --traverse
 <IncludeRoot>/um/wldp.h

--- a/generation/WinSDK/inc/windows.fixed.h
+++ b/generation/WinSDK/inc/windows.fixed.h
@@ -59,5 +59,6 @@
 #undef ReportEvent
 #undef TranslateAccelerator
 #undef CreateDirectory
+#undef DeleteFile
 
 #include <combaseapi.h>

--- a/generation/WinSDK/manual/WinProg.cs
+++ b/generation/WinSDK/manual/WinProg.cs
@@ -1,0 +1,15 @@
+
+using System;
+using System.Runtime.InteropServices;
+using Windows.Win32.Interop;
+
+namespace Windows.Win32.System.WindowsProgramming
+{
+    // Because we can't undef DeleteFile since winbase.h first calls filapi.h and then
+    // has this struct. Without this, the field is named DeleteFileA
+    public partial struct FILE_DISPOSITION_INFO
+    {
+        [NativeTypeName("BOOLEAN")]
+        public byte DeleteFile;
+    }
+}

--- a/scripts/BaselineWinmd/Windows.Win32.winmd
+++ b/scripts/BaselineWinmd/Windows.Win32.winmd
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e8005345961413bbfd6fbac95ad992cf3cd81ed680ecad26bc43b81b8e40427e
+oid sha256:465bdb25127cfe6fce29b7f427e17687c650c87d1aeb559b0d1237ca53988786
 size 16154624


### PR DESCRIPTION
The #define DeleteFile to DeleteFileA in fileaph.h was messing up the struct and a parameter name.
Fixes #986