### PR TITLE
Changes R2_MODE and TEXT_ALIGN_OPTIONS

### DIFF
--- a/generation/WinSDK/enums.json
+++ b/generation/WinSDK/enums.json
@@ -3861,6 +3861,7 @@
     "type": "uint",
     "namespace": "Windows.Win32.Graphics.Gdi",
     "name": "TEXT_ALIGN_OPTIONS",
+    "flags": true,
     "members": [
       {
         "name": "TA_NOUPDATECP",
@@ -3936,6 +3937,10 @@
       {
         "struct": "RICHEDIT_IMAGE_PARAMETERS",
         "field": "Type"
+      },
+      {
+        "method": "GetTextAlign",
+        "parameter": "return"
       },
       {
         "method": "SetTextAlign",
@@ -14715,8 +14720,16 @@
   },
   {
     "addUsesTo": "R2_MODE",
+    "autoPopulate": {
+      "filter": "R2_",
+      "header": "wingdi.h"
+    },
     "members": [],
     "uses": [
+      {
+        "method": "GetROP2",
+        "parameter": "return"
+      },
       {
         "method": "SetROP2",
         "parameter": "rop2"

--- a/scripts/ChangesSinceLastRelease.txt
+++ b/scripts/ChangesSinceLastRelease.txt
@@ -174,3 +174,7 @@ Windows.Win32.UI.WindowsAndMessaging.Apis.UpdateLayeredWindow : crKey...UInt32 =
 Windows.Win32.UI.WindowsAndMessaging.UPDATELAYEREDWINDOWINFO.crKey...System.UInt32 => Windows.Win32.Foundation.COLORREF
 Windows.Win32.UI.Controls.DTTOPTS_FLAGS added
 Windows.Win32.UI.Controls.DTTOPTS.dwFlags...System.UInt32 => Windows.Win32.UI.Controls.DTTOPTS_FLAGS
+# Fixes to R2_MODE and TEXT_ALIGN_OPTIONS
+Windows.Win32.Graphics.Gdi.Apis.GetROP2 : return...Int32 => R2_MODE
+Windows.Win32.Graphics.Gdi.Apis.GetTextAlign : return...UInt32 => TEXT_ALIGN_OPTIONS
+Windows.Win32.Graphics.Gdi.TEXT_ALIGN_OPTIONS :  => [Flags]


### PR DESCRIPTION
Fixes: 
- https://github.com/microsoft/win32metadata/issues/1036
- https://github.com/microsoft/win32metadata/issues/1045
```
Windows.Win32.Graphics.Gdi.TEXT_ALIGN_OPTIONS :  => [Flags]
Windows.Win32.Graphics.Gdi.Apis.GetROP2 : return...Int32 => R2_MODE
Windows.Win32.Graphics.Gdi.Apis.GetTextAlign : return...UInt32 => TEXT_ALIGN_OPTIONS
```