### PR TITLE
Adding enums for OLE

### DIFF
--- a/generation/WinSDK/enums.json
+++ b/generation/WinSDK/enums.json
@@ -31894,6 +31894,525 @@
     },
     "members": [],
     "uses": []
+  },
+  {
+    "name": "ACTIVEOBJECT_FLAGS",
+    "flags": true,
+    "autoPopulate": {
+      "filter": "ACTIVEOBJECT_",
+      "header": "Oleauto.h"
+    },
+    "members": [],
+    "uses": [
+      {
+        "method": "RegisterActiveObject",
+        "parameter": "dwFlags"
+      }
+    ]
+  },
+  {
+    "name": "BUSY_DIALOG_FLAGS",
+    "flags": true,
+    "autoPopulate": {
+      "filter": "BZ_",
+      "header": "Oledlg.h"
+    },
+    "members": [],
+    "uses": [
+      {
+        "struct": "OLEUIBUSYA",
+        "parameter": "dwFlags"
+      },
+      {
+        "struct": "OLEUIBUSYW",
+        "parameter": "dwFlags"
+      }
+    ]
+  },
+  {
+    "name": "UI_CONVERT_FLAGS",
+    "flags": true,
+    "autoPopulate": {
+      "filter": "CF_",
+      "header": "oledlg.h"
+    },
+    "members": [],
+    "uses": [
+      {
+        "method": "OLEUICONVERTA",
+        "parameter": "dwFlags"
+      },
+      {
+        "method": "OLEUICONVERTW",
+        "parameter": "dwFlags"
+      }
+    ]
+  },
+  {
+    "name": "CHANGE_ICON_FLAGS",
+    "type": "int",
+    "flags": true,
+    "autoPopulate": {
+      "filter": "CIF_",
+      "header": "oledlg.h"
+    },
+    "members": [],
+    "uses": [
+      {
+        "method": "OLEUICHANGEICONA",
+        "parameter": "dwFlags"
+      },
+      {
+        "method": "OLEUICHANGEICONW",
+        "parameter": "dwFlags"
+      }
+    ]
+  },
+  {
+    "name": "CHANGE_SOURCE_FLAGS",
+    "flags": true,
+    "autoPopulate": {
+      "filter": "CSF_",
+      "header": "oledlg.h"
+    },
+    "members": [],
+    "uses": [
+      {
+        "method": "OLEUICHANGESOURCEA",
+        "parameter": "dwFlags"
+      },
+      {
+        "method": "OLEUICHANGESOURCEW",
+        "parameter": "dwFlags"
+      }
+    ]
+  },
+  {
+    "name": "EDIT_LINKS_FLAGS",
+    "flags": true,
+    "autoPopulate": {
+      "filter": "ELF_",
+      "header": "oledlg.h"
+    },
+    "members": [],
+    "uses": [
+      {
+        "method": "OLEUIEDITLINKSA",
+        "parameter": "dwFlags"
+      },
+      {
+        "method": "OLEUIEDITLINKSW",
+        "parameter": "dwFlags"
+      }
+    ]
+  },
+  {
+    "name": "INSERT_OBJECT_FLAGS",
+    "flags": true,
+    "autoPopulate": {
+      "filter": "IOF_",
+      "header": "oledlg.h"
+    },
+    "members": [],
+    "uses": [
+      {
+        "method": "OLEUIINSERTOBJECTA",
+        "parameter": "dwFlags"
+      },
+      {
+        "method": "OLEUIINSERTOBJECTW",
+        "parameter": "dwFlags"
+      }
+    ]
+  },
+  {
+    "name": "OBJECT_PROPERTIES_FLAGS",
+    "flags": true,
+    "autoPopulate": {
+      "filter": "OPF_",
+      "header": "oledlg.h"
+    },
+    "members": [],
+    "uses": [
+      {
+        "method": "OLEUIOBJECTPROPSA",
+        "parameter": "dwFlags"
+      },
+      {
+        "method": "OLEUIOBJECTPROPSW",
+        "parameter": "dwFlags"
+      }
+    ]
+  },
+  {
+    "name": "VIEW_OBJECT_PROPERTIES_FLAGS",
+    "flags": true,
+    "autoPopulate": {
+      "filter": "VPF_",
+      "header": "oledlg.h"
+    },
+    "members": [],
+    "uses": [
+      {
+        "method": "OLEUIVIEWPROPSA",
+        "parameter": "dwFlags"
+      },
+      {
+        "method": "OLEUIVIEWPROPSW",
+        "parameter": "dwFlags"
+      }
+    ]
+  },
+  {
+    "name": "FADF",
+    "type": "ushort",
+    "flags": true,
+    "autoPopulate": {
+      "filter": "FADF_",
+      "header": "oaidl.h"
+    },
+    "members": [],
+    "uses": [
+      {
+        "struct": "SAFEARRAY",
+        "field": "fFeatures"
+      }
+    ]
+  },
+  {
+    "name": "DISPATCH",
+    "type": "ushort",
+    "flags": true,
+    "autoPopulate": {
+      "filter": "DISPATCH_",
+      "header": "oaidl.h"
+    },
+    "members": [],
+    "uses": [
+      {
+        "interface": "ITypeInfo",
+        "method": "Invoke",
+        "field": "wFlags"
+      }
+    ]
+  },
+  {
+    "name": "IMPLTYPEFLAGS",
+    "type": "int",
+    "flags": true,
+    "autoPopulate": {
+      "filter": "IMPLTYPEFLAG_",
+      "header": "oaidl.h"
+    },
+    "members": [],
+    "uses": [
+      {
+        "interface": "ITypeInfo",
+        "method": "GetImplTypeFlags",
+        "field": "pImplTypeFlags"
+      },
+      {
+        "interface": "ITypeInfo",
+        "method": "SetImplTypeFlags",
+        "field": "ImplTypeFlags"
+      }
+    ]
+  },
+  {
+    "name": "PARAMFLAGS",
+    "type": "ushort",
+    "flags": true,
+    "autoPopulate": {
+      "filter": "PARAMFLAG_",
+      "header": "oaidl.h"
+    },
+    "members": [],
+    "uses": [
+      {
+        "struct": "PARAMDESC",
+        "field": "wParamFlags"
+      }
+    ]
+  },
+  {
+    "name": "IDLFLAGS",
+    "type": "ushort",
+    "flags": true,
+    "members": [
+      {
+        "name": "IDLFLAG_NONE",
+        "value": "0"
+      },
+      {
+        "name": "IDLFLAG_FIN",
+        "value": "0x1"
+      },
+      {
+        "name": "IDLFLAG_FOUT",
+        "value": "0x2"
+      },
+      {
+        "name": "IDLFLAG_FLCID",
+        "value": "0x4"
+      },
+      {
+        "name": "IDLFLAG_FRETVAL",
+        "value": "0x8"
+      }
+    ],
+    "uses": [
+      {
+        "struct": "IDLDESC",
+        "field": "wIDLFlags"
+      }
+    ]
+  },
+  {
+    "name": "NUMPARSE_FLAGS",
+    "flags": true,
+    "autoPopulate": {
+      "filter": "NUMPRS_",
+      "header": "oleauto.h"
+    },
+    "members": [],
+    "uses": [
+      {
+        "struct": "NUMPARSE",
+        "field": "dwInFlags"
+      },
+      {
+        "struct": "NUMPARSE",
+        "field": "dwOutFlags"
+      }
+    ]
+  },
+  {
+    "name": "PICTYPE",
+    "type": "int",
+    "flags": true,
+    "autoPopulate": {
+      "filter": "PICTYPE_",
+      "header": "olectl.h"
+    },
+    "members": [],
+    "uses": [
+      {
+        "struct": "PICTDESC",
+        "field": "picType"
+      }
+    ]
+  },
+  {
+    "name": "VARCMP",
+    "autoPopulate": {
+      "filter": "VARCMP_",
+      "header": "oleauto.h"
+    },
+    "members": [],
+    "uses": [
+      {
+        "method": "VarCmp",
+        "parameter": "return"
+      },
+      {
+        "method": "VarCyCmp",
+        "parameter": "return"
+      },
+      {
+        "method": "VarCyCmpR8",
+        "parameter": "return"
+      },
+      {
+        "method": "VarDecCmp",
+        "parameter": "return"
+      },
+      {
+        "method": "VarDecCmpR8",
+        "parameter": "return"
+      },
+      {
+        "method": "VarR4CmpR8",
+        "parameter": "return"
+      }
+    ]
+  },
+  {
+    "name": "PASTE_SPECIAL_FLAGS",
+    "flags": true,
+    "autoPopulate": {
+      "filter": "PSF_",
+      "header": "oledlg.h"
+    },
+    "members": [],
+    "uses": [
+      {
+        "struct": "OLEUIPASTESPECIALA",
+        "field": "dwFlags"
+      },
+      {
+        "struct": "OLEUIPASTESPECIALW",
+        "field": "dwFlags"
+      }
+    ]
+  },
+  {
+    "name": "EMBDHLP_FLAGS",
+    "flags": true,
+    "autoPopulate": {
+      "filter": "EMBDHLP_",
+      "header": "ole2.h"
+    },
+    "members": [],
+    "uses": [
+      {
+        "method": "OleCreateEmbeddingHelper",
+        "parameter": "flags"
+      }
+    ]
+  },
+  {
+    "name": "FDEX_PROP_FLAGS",
+    "flags": true,
+    "autoPopulate": {
+      "filter": "fdexProp",
+      "header": "dispex.h"
+    },
+    "members": [],
+    "uses": [
+      {
+        "interface": "IDispatchEx",
+        "method": "GetMemberProperties",
+        "parameter": "pgrfdex"
+      }
+    ]
+  },
+  {
+    "name": "LOAD_PICTURE_FLAGS",
+    "flags": true,
+    "autoPopulate": {
+      "filter": "LP_",
+      "header": "olectl.h"
+    },
+    "members": [],
+    "uses": [
+      {
+        "method": "OleLoadPictureFileEx",
+        "parameter": "dwFlags"
+      },
+      {
+        "method": "OleLoadPictureEx",
+        "parameter": "dwFlags"
+      }
+    ]
+  },
+  {
+    "type": "uint",
+    "addUsesTo": "CTRLINFO",
+    "members": [],
+    "uses": [
+      {
+        "struct": "CONTROLINFO",
+        "parameter": "dwFlags"
+      }
+    ]
+  },
+  {
+    "name": "OLECREATE",
+    "autoPopulate": {
+      "filter": "OLECREATE_",
+      "header": "ole2.h"
+    },
+    "members": [
+      {
+        "name": "OLECREATE_ZERO",
+        "value": "0"
+      }
+    ],
+    "uses": [
+      {
+        "method": "OleCreateEx",
+        "parameter": "dwFlags"
+      },
+      {
+        "method": "OleCreateFromDataEx",
+        "parameter": "dwFlags"
+      },
+      {
+        "method": "OleCreateFromFileEx",
+        "parameter": "dwFlags"
+      },
+      {
+        "method": "OleCreateLinkEx",
+        "parameter": "dwFlags"
+      },
+      {
+        "method": "OleCreateLinkFromDataEx",
+        "parameter": "dwFlags"
+      },
+      {
+        "method": "OleCreateLinkToFileEx",
+        "parameter": "dwFlags"
+      }
+    ]
+  },
+  {
+    "type": "uint",
+    "addUsesTo": "OLERENDER",
+    "members": [],
+    "uses": [
+      {
+        "method": "OleCreate",
+        "parameter": "renderopt"
+      },
+      {
+        "method": "OleCreateEx",
+        "parameter": "renderopt"
+      },
+      {
+        "method": "OleCreateFromData",
+        "parameter": "renderopt"
+      },
+      {
+        "method": "OleCreateFromDataEx",
+        "parameter": "renderopt"
+      },
+      {
+        "method": "OleCreateFromFile",
+        "parameter": "renderopt"
+      },
+      {
+        "method": "OleCreateFromFileEx",
+        "parameter": "renderopt"
+      },
+      {
+        "method": "OleCreateLink",
+        "parameter": "renderopt"
+      },
+      {
+        "method": "OleCreateLinkEx",
+        "parameter": "renderopt"
+      },
+      {
+        "method": "OleCreateLinkFromData",
+        "parameter": "renderopt"
+      },
+      {
+        "method": "OleCreateLinkFromDataEx",
+        "parameter": "renderopt"
+      },
+      {
+        "method": "OleCreateLinkToFile",
+        "parameter": "renderopt"
+      },
+      {
+        "method": "OleCreateLinkToFileEx",
+        "parameter": "renderopt"
+      },
+      {
+        "method": "OleCreateStaticFromData",
+        "parameter": "renderopt"
+      }
+    ]
   }
 ]
 }

--- a/scripts/ChangesSinceLastRelease.txt
+++ b/scripts/ChangesSinceLastRelease.txt
@@ -1,0 +1,321 @@
+# OLE enum changes
+Windows.Win32.System.Com.IDLDESC.wIDLFlags...System.UInt16 => Windows.Win32.System.Com.IDLFLAGS
+Windows.Win32.System.Com.IDLFLAGS added
+Windows.Win32.System.Com.IDLFLAGS.IDLFLAG_FIN added
+Windows.Win32.System.Com.IDLFLAGS.IDLFLAG_FLCID added
+Windows.Win32.System.Com.IDLFLAGS.IDLFLAG_FOUT added
+Windows.Win32.System.Com.IDLFLAGS.IDLFLAG_FRETVAL added
+Windows.Win32.System.Com.IDLFLAGS.IDLFLAG_NONE added
+Windows.Win32.System.Com.IMPLTYPEFLAGS added
+Windows.Win32.System.Com.IMPLTYPEFLAGS.IMPLTYPEFLAG_FDEFAULT added
+Windows.Win32.System.Com.IMPLTYPEFLAGS.IMPLTYPEFLAG_FDEFAULTVTABLE added
+Windows.Win32.System.Com.IMPLTYPEFLAGS.IMPLTYPEFLAG_FRESTRICTED added
+Windows.Win32.System.Com.IMPLTYPEFLAGS.IMPLTYPEFLAG_FSOURCE added
+Windows.Win32.System.Ole.ACTIVEOBJECT_FLAGS added
+Windows.Win32.System.Ole.ACTIVEOBJECT_FLAGS.ACTIVEOBJECT_STRONG added
+Windows.Win32.System.Ole.ACTIVEOBJECT_FLAGS.ACTIVEOBJECT_WEAK added
+Windows.Win32.System.Ole.Apis.ACTIVEOBJECT_STRONG removed
+Windows.Win32.System.Ole.Apis.ACTIVEOBJECT_WEAK removed
+Windows.Win32.System.Ole.Apis.BZ_DISABLECANCELBUTTON removed
+Windows.Win32.System.Ole.Apis.BZ_DISABLERETRYBUTTON removed
+Windows.Win32.System.Ole.Apis.BZ_DISABLESWITCHTOBUTTON removed
+Windows.Win32.System.Ole.Apis.BZ_NOTRESPONDINGDIALOG removed
+Windows.Win32.System.Ole.Apis.CF_CONVERTONLY removed
+Windows.Win32.System.Ole.Apis.CF_DISABLEACTIVATEAS removed
+Windows.Win32.System.Ole.Apis.CF_DISABLEDISPLAYASICON removed
+Windows.Win32.System.Ole.Apis.CF_HIDECHANGEICON removed
+Windows.Win32.System.Ole.Apis.CF_SELECTACTIVATEAS removed
+Windows.Win32.System.Ole.Apis.CF_SELECTCONVERTTO removed
+Windows.Win32.System.Ole.Apis.CF_SETACTIVATEDEFAULT removed
+Windows.Win32.System.Ole.Apis.CF_SETCONVERTDEFAULT removed
+Windows.Win32.System.Ole.Apis.CF_SHOWHELPBUTTON removed
+Windows.Win32.System.Ole.Apis.CIF_SELECTCURRENT removed
+Windows.Win32.System.Ole.Apis.CIF_SELECTDEFAULT removed
+Windows.Win32.System.Ole.Apis.CIF_SELECTFROMFILE removed
+Windows.Win32.System.Ole.Apis.CIF_SHOWHELP removed
+Windows.Win32.System.Ole.Apis.CIF_USEICONEXE removed
+Windows.Win32.System.Ole.Apis.CSF_EXPLORER removed
+Windows.Win32.System.Ole.Apis.CSF_ONLYGETSOURCE removed
+Windows.Win32.System.Ole.Apis.CSF_SHOWHELP removed
+Windows.Win32.System.Ole.Apis.CSF_VALIDSOURCE removed
+Windows.Win32.System.Ole.Apis.ELF_DISABLECANCELLINK removed
+Windows.Win32.System.Ole.Apis.ELF_DISABLECHANGESOURCE removed
+Windows.Win32.System.Ole.Apis.ELF_DISABLEOPENSOURCE removed
+Windows.Win32.System.Ole.Apis.ELF_DISABLEUPDATENOW removed
+Windows.Win32.System.Ole.Apis.ELF_SHOWHELP removed
+Windows.Win32.System.Ole.Apis.EMBDHLP_CREATENOW removed
+Windows.Win32.System.Ole.Apis.EMBDHLP_DELAYCREATE removed
+Windows.Win32.System.Ole.Apis.EMBDHLP_INPROC_HANDLER removed
+Windows.Win32.System.Ole.Apis.EMBDHLP_INPROC_SERVER removed
+Windows.Win32.System.Ole.Apis.fdexPropCanCall removed
+Windows.Win32.System.Ole.Apis.fdexPropCanConstruct removed
+Windows.Win32.System.Ole.Apis.fdexPropCanGet removed
+Windows.Win32.System.Ole.Apis.fdexPropCannotCall removed
+Windows.Win32.System.Ole.Apis.fdexPropCannotConstruct removed
+Windows.Win32.System.Ole.Apis.fdexPropCannotGet removed
+Windows.Win32.System.Ole.Apis.fdexPropCannotPut removed
+Windows.Win32.System.Ole.Apis.fdexPropCannotPutRef removed
+Windows.Win32.System.Ole.Apis.fdexPropCannotSourceEvents removed
+Windows.Win32.System.Ole.Apis.fdexPropCanPut removed
+Windows.Win32.System.Ole.Apis.fdexPropCanPutRef removed
+Windows.Win32.System.Ole.Apis.fdexPropCanSourceEvents removed
+Windows.Win32.System.Ole.Apis.fdexPropDynamicType removed
+Windows.Win32.System.Ole.Apis.fdexPropNoSideEffects removed
+Windows.Win32.System.Ole.Apis.IDLFLAG_FIN removed
+Windows.Win32.System.Ole.Apis.IDLFLAG_FLCID removed
+Windows.Win32.System.Ole.Apis.IDLFLAG_FOUT removed
+Windows.Win32.System.Ole.Apis.IDLFLAG_FRETVAL removed
+Windows.Win32.System.Ole.Apis.IDLFLAG_NONE removed
+Windows.Win32.System.Ole.Apis.IMPLTYPEFLAG_FDEFAULT removed
+Windows.Win32.System.Ole.Apis.IMPLTYPEFLAG_FDEFAULTVTABLE removed
+Windows.Win32.System.Ole.Apis.IMPLTYPEFLAG_FRESTRICTED removed
+Windows.Win32.System.Ole.Apis.IMPLTYPEFLAG_FSOURCE removed
+Windows.Win32.System.Ole.Apis.IOF_CHECKDISPLAYASICON removed
+Windows.Win32.System.Ole.Apis.IOF_CHECKLINK removed
+Windows.Win32.System.Ole.Apis.IOF_CREATEFILEOBJECT removed
+Windows.Win32.System.Ole.Apis.IOF_CREATELINKOBJECT removed
+Windows.Win32.System.Ole.Apis.IOF_CREATENEWOBJECT removed
+Windows.Win32.System.Ole.Apis.IOF_DISABLEDISPLAYASICON removed
+Windows.Win32.System.Ole.Apis.IOF_DISABLELINK removed
+Windows.Win32.System.Ole.Apis.IOF_HIDECHANGEICON removed
+Windows.Win32.System.Ole.Apis.IOF_SELECTCREATECONTROL removed
+Windows.Win32.System.Ole.Apis.IOF_SELECTCREATEFROMFILE removed
+Windows.Win32.System.Ole.Apis.IOF_SELECTCREATENEW removed
+Windows.Win32.System.Ole.Apis.IOF_SHOWHELP removed
+Windows.Win32.System.Ole.Apis.IOF_SHOWINSERTCONTROL removed
+Windows.Win32.System.Ole.Apis.IOF_VERIFYSERVERSEXIST removed
+Windows.Win32.System.Ole.Apis.LP_COLOR removed
+Windows.Win32.System.Ole.Apis.LP_DEFAULT removed
+Windows.Win32.System.Ole.Apis.LP_MONOCHROME removed
+Windows.Win32.System.Ole.Apis.LP_VGACOLOR removed
+Windows.Win32.System.Ole.Apis.NUMPRS_CURRENCY removed
+Windows.Win32.System.Ole.Apis.NUMPRS_DECIMAL removed
+Windows.Win32.System.Ole.Apis.NUMPRS_EXPONENT removed
+Windows.Win32.System.Ole.Apis.NUMPRS_HEX_OCT removed
+Windows.Win32.System.Ole.Apis.NUMPRS_INEXACT removed
+Windows.Win32.System.Ole.Apis.NUMPRS_LEADING_MINUS removed
+Windows.Win32.System.Ole.Apis.NUMPRS_LEADING_PLUS removed
+Windows.Win32.System.Ole.Apis.NUMPRS_LEADING_WHITE removed
+Windows.Win32.System.Ole.Apis.NUMPRS_NEG removed
+Windows.Win32.System.Ole.Apis.NUMPRS_PARENS removed
+Windows.Win32.System.Ole.Apis.NUMPRS_STD removed
+Windows.Win32.System.Ole.Apis.NUMPRS_THOUSANDS removed
+Windows.Win32.System.Ole.Apis.NUMPRS_TRAILING_MINUS removed
+Windows.Win32.System.Ole.Apis.NUMPRS_TRAILING_PLUS removed
+Windows.Win32.System.Ole.Apis.NUMPRS_TRAILING_WHITE removed
+Windows.Win32.System.Ole.Apis.NUMPRS_USE_ALL removed
+Windows.Win32.System.Ole.Apis.OleCreate : renderopt...UInt32 => OLERENDER
+Windows.Win32.System.Ole.Apis.OLECREATE_LEAVERUNNING removed
+Windows.Win32.System.Ole.Apis.OleCreateEmbeddingHelper : flags...UInt32 => EMBDHLP_FLAGS
+Windows.Win32.System.Ole.Apis.OleCreateEx : dwFlags...UInt32 => OLECREATE
+Windows.Win32.System.Ole.Apis.OleCreateEx : renderopt...UInt32 => OLERENDER
+Windows.Win32.System.Ole.Apis.OleCreateFromData : renderopt...UInt32 => OLERENDER
+Windows.Win32.System.Ole.Apis.OleCreateFromDataEx : dwFlags...UInt32 => OLECREATE
+Windows.Win32.System.Ole.Apis.OleCreateFromDataEx : renderopt...UInt32 => OLERENDER
+Windows.Win32.System.Ole.Apis.OleCreateFromFile : renderopt...UInt32 => OLERENDER
+Windows.Win32.System.Ole.Apis.OleCreateFromFileEx : dwFlags...UInt32 => OLECREATE
+Windows.Win32.System.Ole.Apis.OleCreateFromFileEx : renderopt...UInt32 => OLERENDER
+Windows.Win32.System.Ole.Apis.OleCreateLink : renderopt...UInt32 => OLERENDER
+Windows.Win32.System.Ole.Apis.OleCreateLinkEx : dwFlags...UInt32 => OLECREATE
+Windows.Win32.System.Ole.Apis.OleCreateLinkEx : renderopt...UInt32 => OLERENDER
+Windows.Win32.System.Ole.Apis.OleCreateLinkFromData : renderopt...UInt32 => OLERENDER
+Windows.Win32.System.Ole.Apis.OleCreateLinkFromDataEx : dwFlags...UInt32 => OLECREATE
+Windows.Win32.System.Ole.Apis.OleCreateLinkFromDataEx : renderopt...UInt32 => OLERENDER
+Windows.Win32.System.Ole.Apis.OleCreateLinkToFile : renderopt...UInt32 => OLERENDER
+Windows.Win32.System.Ole.Apis.OleCreateLinkToFileEx : dwFlags...UInt32 => OLECREATE
+Windows.Win32.System.Ole.Apis.OleCreateLinkToFileEx : renderopt...UInt32 => OLERENDER
+Windows.Win32.System.Ole.Apis.OleCreateStaticFromData : renderopt...UInt32 => OLERENDER
+Windows.Win32.System.Ole.Apis.OleLoadPictureEx : dwFlags...UInt32 => LOAD_PICTURE_FLAGS
+Windows.Win32.System.Ole.Apis.OleLoadPictureFileEx : dwFlags...UInt32 => LOAD_PICTURE_FLAGS
+Windows.Win32.System.Ole.Apis.OPF_DISABLECONVERT removed
+Windows.Win32.System.Ole.Apis.OPF_NOFILLDEFAULT removed
+Windows.Win32.System.Ole.Apis.OPF_OBJECTISLINK removed
+Windows.Win32.System.Ole.Apis.OPF_SHOWHELP removed
+Windows.Win32.System.Ole.Apis.PARAMFLAG_FHASCUSTDATA removed
+Windows.Win32.System.Ole.Apis.PARAMFLAG_FHASDEFAULT removed
+Windows.Win32.System.Ole.Apis.PARAMFLAG_FIN removed
+Windows.Win32.System.Ole.Apis.PARAMFLAG_FLCID removed
+Windows.Win32.System.Ole.Apis.PARAMFLAG_FOPT removed
+Windows.Win32.System.Ole.Apis.PARAMFLAG_FOUT removed
+Windows.Win32.System.Ole.Apis.PARAMFLAG_FRETVAL removed
+Windows.Win32.System.Ole.Apis.PARAMFLAG_NONE removed
+Windows.Win32.System.Ole.Apis.PICTYPE_BITMAP removed
+Windows.Win32.System.Ole.Apis.PICTYPE_ENHMETAFILE removed
+Windows.Win32.System.Ole.Apis.PICTYPE_ICON removed
+Windows.Win32.System.Ole.Apis.PICTYPE_METAFILE removed
+Windows.Win32.System.Ole.Apis.PICTYPE_NONE removed
+Windows.Win32.System.Ole.Apis.PICTYPE_UNINITIALIZED removed
+Windows.Win32.System.Ole.Apis.PSF_CHECKDISPLAYASICON removed
+Windows.Win32.System.Ole.Apis.PSF_DISABLEDISPLAYASICON removed
+Windows.Win32.System.Ole.Apis.PSF_HIDECHANGEICON removed
+Windows.Win32.System.Ole.Apis.PSF_NOREFRESHDATAOBJECT removed
+Windows.Win32.System.Ole.Apis.PSF_SELECTPASTE removed
+Windows.Win32.System.Ole.Apis.PSF_SELECTPASTELINK removed
+Windows.Win32.System.Ole.Apis.PSF_SHOWHELP removed
+Windows.Win32.System.Ole.Apis.PSF_STAYONCLIPBOARDCHANGE removed
+Windows.Win32.System.Ole.Apis.RegisterActiveObject : dwFlags...UInt32 => ACTIVEOBJECT_FLAGS
+Windows.Win32.System.Ole.Apis.VarCmp : return...HRESULT => VARCMP
+Windows.Win32.System.Ole.Apis.VARCMP_EQ removed
+Windows.Win32.System.Ole.Apis.VARCMP_GT removed
+Windows.Win32.System.Ole.Apis.VARCMP_LT removed
+Windows.Win32.System.Ole.Apis.VARCMP_NULL removed
+Windows.Win32.System.Ole.Apis.VarCyCmp : return...HRESULT => VARCMP
+Windows.Win32.System.Ole.Apis.VarCyCmpR8 : return...HRESULT => VARCMP
+Windows.Win32.System.Ole.Apis.VarDecCmp : return...HRESULT => VARCMP
+Windows.Win32.System.Ole.Apis.VarDecCmpR8 : return...HRESULT => VARCMP
+Windows.Win32.System.Ole.Apis.VarR4CmpR8 : return...HRESULT => VARCMP
+Windows.Win32.System.Ole.Apis.VPF_DISABLERELATIVE removed
+Windows.Win32.System.Ole.Apis.VPF_DISABLESCALE removed
+Windows.Win32.System.Ole.Apis.VPF_SELECTRELATIVE removed
+Windows.Win32.System.Ole.BUSY_DIALOG_FLAGS added
+Windows.Win32.System.Ole.BUSY_DIALOG_FLAGS.BZ_DISABLECANCELBUTTON added
+Windows.Win32.System.Ole.BUSY_DIALOG_FLAGS.BZ_DISABLERETRYBUTTON added
+Windows.Win32.System.Ole.BUSY_DIALOG_FLAGS.BZ_DISABLESWITCHTOBUTTON added
+Windows.Win32.System.Ole.BUSY_DIALOG_FLAGS.BZ_NOTRESPONDINGDIALOG added
+Windows.Win32.System.Ole.CHANGE_ICON_FLAGS added
+Windows.Win32.System.Ole.CHANGE_ICON_FLAGS.CIF_SELECTCURRENT added
+Windows.Win32.System.Ole.CHANGE_ICON_FLAGS.CIF_SELECTDEFAULT added
+Windows.Win32.System.Ole.CHANGE_ICON_FLAGS.CIF_SELECTFROMFILE added
+Windows.Win32.System.Ole.CHANGE_ICON_FLAGS.CIF_SHOWHELP added
+Windows.Win32.System.Ole.CHANGE_ICON_FLAGS.CIF_USEICONEXE added
+Windows.Win32.System.Ole.CHANGE_SOURCE_FLAGS added
+Windows.Win32.System.Ole.CHANGE_SOURCE_FLAGS.CSF_EXPLORER added
+Windows.Win32.System.Ole.CHANGE_SOURCE_FLAGS.CSF_ONLYGETSOURCE added
+Windows.Win32.System.Ole.CHANGE_SOURCE_FLAGS.CSF_SHOWHELP added
+Windows.Win32.System.Ole.CHANGE_SOURCE_FLAGS.CSF_VALIDSOURCE added
+Windows.Win32.System.Ole.EDIT_LINKS_FLAGS added
+Windows.Win32.System.Ole.EDIT_LINKS_FLAGS.ELF_DISABLECANCELLINK added
+Windows.Win32.System.Ole.EDIT_LINKS_FLAGS.ELF_DISABLECHANGESOURCE added
+Windows.Win32.System.Ole.EDIT_LINKS_FLAGS.ELF_DISABLEOPENSOURCE added
+Windows.Win32.System.Ole.EDIT_LINKS_FLAGS.ELF_DISABLEUPDATENOW added
+Windows.Win32.System.Ole.EDIT_LINKS_FLAGS.ELF_SHOWHELP added
+Windows.Win32.System.Ole.EMBDHLP_FLAGS added
+Windows.Win32.System.Ole.EMBDHLP_FLAGS.EMBDHLP_CREATENOW added
+Windows.Win32.System.Ole.EMBDHLP_FLAGS.EMBDHLP_DELAYCREATE added
+Windows.Win32.System.Ole.EMBDHLP_FLAGS.EMBDHLP_INPROC_HANDLER added
+Windows.Win32.System.Ole.EMBDHLP_FLAGS.EMBDHLP_INPROC_SERVER added
+Windows.Win32.System.Ole.FDEX_PROP_FLAGS added
+Windows.Win32.System.Ole.FDEX_PROP_FLAGS.fdexPropCanCall added
+Windows.Win32.System.Ole.FDEX_PROP_FLAGS.fdexPropCanConstruct added
+Windows.Win32.System.Ole.FDEX_PROP_FLAGS.fdexPropCanGet added
+Windows.Win32.System.Ole.FDEX_PROP_FLAGS.fdexPropCannotCall added
+Windows.Win32.System.Ole.FDEX_PROP_FLAGS.fdexPropCannotConstruct added
+Windows.Win32.System.Ole.FDEX_PROP_FLAGS.fdexPropCannotGet added
+Windows.Win32.System.Ole.FDEX_PROP_FLAGS.fdexPropCannotPut added
+Windows.Win32.System.Ole.FDEX_PROP_FLAGS.fdexPropCannotPutRef added
+Windows.Win32.System.Ole.FDEX_PROP_FLAGS.fdexPropCannotSourceEvents added
+Windows.Win32.System.Ole.FDEX_PROP_FLAGS.fdexPropCanPut added
+Windows.Win32.System.Ole.FDEX_PROP_FLAGS.fdexPropCanPutRef added
+Windows.Win32.System.Ole.FDEX_PROP_FLAGS.fdexPropCanSourceEvents added
+Windows.Win32.System.Ole.FDEX_PROP_FLAGS.fdexPropDynamicType added
+Windows.Win32.System.Ole.FDEX_PROP_FLAGS.fdexPropNoSideEffects added
+Windows.Win32.System.Ole.IDispatchEx.GetMemberProperties : pgrfdex...UInt32* => FDEX_PROP_FLAGS*
+Windows.Win32.System.Ole.INSERT_OBJECT_FLAGS added
+Windows.Win32.System.Ole.INSERT_OBJECT_FLAGS.IOF_CHECKDISPLAYASICON added
+Windows.Win32.System.Ole.INSERT_OBJECT_FLAGS.IOF_CHECKLINK added
+Windows.Win32.System.Ole.INSERT_OBJECT_FLAGS.IOF_CREATEFILEOBJECT added
+Windows.Win32.System.Ole.INSERT_OBJECT_FLAGS.IOF_CREATELINKOBJECT added
+Windows.Win32.System.Ole.INSERT_OBJECT_FLAGS.IOF_CREATENEWOBJECT added
+Windows.Win32.System.Ole.INSERT_OBJECT_FLAGS.IOF_DISABLEDISPLAYASICON added
+Windows.Win32.System.Ole.INSERT_OBJECT_FLAGS.IOF_DISABLELINK added
+Windows.Win32.System.Ole.INSERT_OBJECT_FLAGS.IOF_HIDECHANGEICON added
+Windows.Win32.System.Ole.INSERT_OBJECT_FLAGS.IOF_SELECTCREATECONTROL added
+Windows.Win32.System.Ole.INSERT_OBJECT_FLAGS.IOF_SELECTCREATEFROMFILE added
+Windows.Win32.System.Ole.INSERT_OBJECT_FLAGS.IOF_SELECTCREATENEW added
+Windows.Win32.System.Ole.INSERT_OBJECT_FLAGS.IOF_SHOWHELP added
+Windows.Win32.System.Ole.INSERT_OBJECT_FLAGS.IOF_SHOWINSERTCONTROL added
+Windows.Win32.System.Ole.INSERT_OBJECT_FLAGS.IOF_VERIFYSERVERSEXIST added
+Windows.Win32.System.Ole.LOAD_PICTURE_FLAGS added
+Windows.Win32.System.Ole.LOAD_PICTURE_FLAGS.LP_COLOR added
+Windows.Win32.System.Ole.LOAD_PICTURE_FLAGS.LP_DEFAULT added
+Windows.Win32.System.Ole.LOAD_PICTURE_FLAGS.LP_MONOCHROME added
+Windows.Win32.System.Ole.LOAD_PICTURE_FLAGS.LP_VGACOLOR added
+Windows.Win32.System.Ole.NUMPARSE_FLAGS added
+Windows.Win32.System.Ole.NUMPARSE_FLAGS.NUMPRS_CURRENCY added
+Windows.Win32.System.Ole.NUMPARSE_FLAGS.NUMPRS_DECIMAL added
+Windows.Win32.System.Ole.NUMPARSE_FLAGS.NUMPRS_EXPONENT added
+Windows.Win32.System.Ole.NUMPARSE_FLAGS.NUMPRS_HEX_OCT added
+Windows.Win32.System.Ole.NUMPARSE_FLAGS.NUMPRS_INEXACT added
+Windows.Win32.System.Ole.NUMPARSE_FLAGS.NUMPRS_LEADING_MINUS added
+Windows.Win32.System.Ole.NUMPARSE_FLAGS.NUMPRS_LEADING_PLUS added
+Windows.Win32.System.Ole.NUMPARSE_FLAGS.NUMPRS_LEADING_WHITE added
+Windows.Win32.System.Ole.NUMPARSE_FLAGS.NUMPRS_NEG added
+Windows.Win32.System.Ole.NUMPARSE_FLAGS.NUMPRS_PARENS added
+Windows.Win32.System.Ole.NUMPARSE_FLAGS.NUMPRS_STD added
+Windows.Win32.System.Ole.NUMPARSE_FLAGS.NUMPRS_THOUSANDS added
+Windows.Win32.System.Ole.NUMPARSE_FLAGS.NUMPRS_TRAILING_MINUS added
+Windows.Win32.System.Ole.NUMPARSE_FLAGS.NUMPRS_TRAILING_PLUS added
+Windows.Win32.System.Ole.NUMPARSE_FLAGS.NUMPRS_TRAILING_WHITE added
+Windows.Win32.System.Ole.NUMPARSE_FLAGS.NUMPRS_USE_ALL added
+Windows.Win32.System.Ole.NUMPARSE.dwInFlags...System.UInt32 => Windows.Win32.System.Ole.NUMPARSE_FLAGS
+Windows.Win32.System.Ole.NUMPARSE.dwOutFlags...System.UInt32 => Windows.Win32.System.Ole.NUMPARSE_FLAGS
+Windows.Win32.System.Ole.OBJECT_PROPERTIES_FLAGS added
+Windows.Win32.System.Ole.OBJECT_PROPERTIES_FLAGS.OPF_DISABLECONVERT added
+Windows.Win32.System.Ole.OBJECT_PROPERTIES_FLAGS.OPF_NOFILLDEFAULT added
+Windows.Win32.System.Ole.OBJECT_PROPERTIES_FLAGS.OPF_OBJECTISLINK added
+Windows.Win32.System.Ole.OBJECT_PROPERTIES_FLAGS.OPF_SHOWHELP added
+Windows.Win32.System.Ole.OLECREATE added
+Windows.Win32.System.Ole.OLECREATE.OLECREATE_LEAVERUNNING added
+Windows.Win32.System.Ole.OLECREATE.OLECREATE_ZERO added
+Windows.Win32.System.Ole.OLEUICHANGEICONA.dwFlags...System.UInt32 => Windows.Win32.System.Ole.CHANGE_ICON_FLAGS
+Windows.Win32.System.Ole.OLEUICHANGEICONW.dwFlags...System.UInt32 => Windows.Win32.System.Ole.CHANGE_ICON_FLAGS
+Windows.Win32.System.Ole.OLEUICHANGESOURCEA.dwFlags...System.UInt32 => Windows.Win32.System.Ole.CHANGE_SOURCE_FLAGS
+Windows.Win32.System.Ole.OLEUICHANGESOURCEW.dwFlags...System.UInt32 => Windows.Win32.System.Ole.CHANGE_SOURCE_FLAGS
+Windows.Win32.System.Ole.OLEUICONVERTA.dwFlags...System.UInt32 => Windows.Win32.System.Ole.UI_CONVERT_FLAGS
+Windows.Win32.System.Ole.OLEUICONVERTW.dwFlags...System.UInt32 => Windows.Win32.System.Ole.UI_CONVERT_FLAGS
+Windows.Win32.System.Ole.OLEUIEDITLINKSA.dwFlags...System.UInt32 => Windows.Win32.System.Ole.EDIT_LINKS_FLAGS
+Windows.Win32.System.Ole.OLEUIEDITLINKSW.dwFlags...System.UInt32 => Windows.Win32.System.Ole.EDIT_LINKS_FLAGS
+Windows.Win32.System.Ole.OLEUIINSERTOBJECTA.dwFlags...System.UInt32 => Windows.Win32.System.Ole.INSERT_OBJECT_FLAGS
+Windows.Win32.System.Ole.OLEUIINSERTOBJECTW.dwFlags...System.UInt32 => Windows.Win32.System.Ole.INSERT_OBJECT_FLAGS
+Windows.Win32.System.Ole.OLEUIOBJECTPROPSA.dwFlags...System.UInt32 => Windows.Win32.System.Ole.OBJECT_PROPERTIES_FLAGS
+Windows.Win32.System.Ole.OLEUIOBJECTPROPSW.dwFlags...System.UInt32 => Windows.Win32.System.Ole.OBJECT_PROPERTIES_FLAGS
+Windows.Win32.System.Ole.OLEUIPASTESPECIALA.dwFlags...System.UInt32 => Windows.Win32.System.Ole.PASTE_SPECIAL_FLAGS
+Windows.Win32.System.Ole.OLEUIPASTESPECIALW.dwFlags...System.UInt32 => Windows.Win32.System.Ole.PASTE_SPECIAL_FLAGS
+Windows.Win32.System.Ole.OLEUIVIEWPROPSA.dwFlags...System.UInt32 => Windows.Win32.System.Ole.VIEW_OBJECT_PROPERTIES_FLAGS
+Windows.Win32.System.Ole.OLEUIVIEWPROPSW.dwFlags...System.UInt32 => Windows.Win32.System.Ole.VIEW_OBJECT_PROPERTIES_FLAGS
+Windows.Win32.System.Ole.PARAMDESC.wParamFlags...System.UInt16 => Windows.Win32.System.Ole.PARAMFLAGS
+Windows.Win32.System.Ole.PARAMFLAGS added
+Windows.Win32.System.Ole.PARAMFLAGS.PARAMFLAG_FHASCUSTDATA added
+Windows.Win32.System.Ole.PARAMFLAGS.PARAMFLAG_FHASDEFAULT added
+Windows.Win32.System.Ole.PARAMFLAGS.PARAMFLAG_FIN added
+Windows.Win32.System.Ole.PARAMFLAGS.PARAMFLAG_FLCID added
+Windows.Win32.System.Ole.PARAMFLAGS.PARAMFLAG_FOPT added
+Windows.Win32.System.Ole.PARAMFLAGS.PARAMFLAG_FOUT added
+Windows.Win32.System.Ole.PARAMFLAGS.PARAMFLAG_FRETVAL added
+Windows.Win32.System.Ole.PARAMFLAGS.PARAMFLAG_NONE added
+Windows.Win32.System.Ole.PASTE_SPECIAL_FLAGS added
+Windows.Win32.System.Ole.PASTE_SPECIAL_FLAGS.PSF_CHECKDISPLAYASICON added
+Windows.Win32.System.Ole.PASTE_SPECIAL_FLAGS.PSF_DISABLEDISPLAYASICON added
+Windows.Win32.System.Ole.PASTE_SPECIAL_FLAGS.PSF_HIDECHANGEICON added
+Windows.Win32.System.Ole.PASTE_SPECIAL_FLAGS.PSF_NOREFRESHDATAOBJECT added
+Windows.Win32.System.Ole.PASTE_SPECIAL_FLAGS.PSF_SELECTPASTE added
+Windows.Win32.System.Ole.PASTE_SPECIAL_FLAGS.PSF_SELECTPASTELINK added
+Windows.Win32.System.Ole.PASTE_SPECIAL_FLAGS.PSF_SHOWHELP added
+Windows.Win32.System.Ole.PASTE_SPECIAL_FLAGS.PSF_STAYONCLIPBOARDCHANGE added
+Windows.Win32.System.Ole.PICTDESC.picType...System.UInt32 => Windows.Win32.System.Ole.PICTYPE
+Windows.Win32.System.Ole.PICTYPE added
+Windows.Win32.System.Ole.PICTYPE.PICTYPE_BITMAP added
+Windows.Win32.System.Ole.PICTYPE.PICTYPE_ENHMETAFILE added
+Windows.Win32.System.Ole.PICTYPE.PICTYPE_ICON added
+Windows.Win32.System.Ole.PICTYPE.PICTYPE_METAFILE added
+Windows.Win32.System.Ole.PICTYPE.PICTYPE_NONE added
+Windows.Win32.System.Ole.PICTYPE.PICTYPE_UNINITIALIZED added
+Windows.Win32.System.Ole.UI_CONVERT_FLAGS added
+Windows.Win32.System.Ole.UI_CONVERT_FLAGS.CF_CONVERTONLY added
+Windows.Win32.System.Ole.UI_CONVERT_FLAGS.CF_DISABLEACTIVATEAS added
+Windows.Win32.System.Ole.UI_CONVERT_FLAGS.CF_DISABLEDISPLAYASICON added
+Windows.Win32.System.Ole.UI_CONVERT_FLAGS.CF_HIDECHANGEICON added
+Windows.Win32.System.Ole.UI_CONVERT_FLAGS.CF_SELECTACTIVATEAS added
+Windows.Win32.System.Ole.UI_CONVERT_FLAGS.CF_SELECTCONVERTTO added
+Windows.Win32.System.Ole.UI_CONVERT_FLAGS.CF_SETACTIVATEDEFAULT added
+Windows.Win32.System.Ole.UI_CONVERT_FLAGS.CF_SETCONVERTDEFAULT added
+Windows.Win32.System.Ole.UI_CONVERT_FLAGS.CF_SHOWHELPBUTTON added
+Windows.Win32.System.Ole.VARCMP added
+Windows.Win32.System.Ole.VARCMP.VARCMP_EQ added
+Windows.Win32.System.Ole.VARCMP.VARCMP_GT added
+Windows.Win32.System.Ole.VARCMP.VARCMP_LT added
+Windows.Win32.System.Ole.VARCMP.VARCMP_NULL added
+Windows.Win32.System.Ole.VIEW_OBJECT_PROPERTIES_FLAGS added
+Windows.Win32.System.Ole.VIEW_OBJECT_PROPERTIES_FLAGS.VPF_DISABLERELATIVE added
+Windows.Win32.System.Ole.VIEW_OBJECT_PROPERTIES_FLAGS.VPF_DISABLESCALE added
+Windows.Win32.System.Ole.VIEW_OBJECT_PROPERTIES_FLAGS.VPF_SELECTRELATIVE added


### PR DESCRIPTION
I have been going through the Windows.Win32.System.Ole.Api namespace and adding enums.

Fixes: #1090 (doesn't cover it entirely, issue needs discussion)
Fixes: #1091
Fixes: #1144
Fixes: #1155
Fixes: #1154

```
Windows.Win32.System.Com.IDLDESC.wIDLFlags...System.UInt16 => Windows.Win32.System.Com.IDLFLAGS
Windows.Win32.System.Com.IDLFLAGS added
Windows.Win32.System.Com.IDLFLAGS.IDLFLAG_FIN added
Windows.Win32.System.Com.IDLFLAGS.IDLFLAG_FLCID added
Windows.Win32.System.Com.IDLFLAGS.IDLFLAG_FOUT added
Windows.Win32.System.Com.IDLFLAGS.IDLFLAG_FRETVAL added
Windows.Win32.System.Com.IDLFLAGS.IDLFLAG_NONE added
Windows.Win32.System.Com.IMPLTYPEFLAGS added
Windows.Win32.System.Com.IMPLTYPEFLAGS.IMPLTYPEFLAG_FDEFAULT added
Windows.Win32.System.Com.IMPLTYPEFLAGS.IMPLTYPEFLAG_FDEFAULTVTABLE added
Windows.Win32.System.Com.IMPLTYPEFLAGS.IMPLTYPEFLAG_FRESTRICTED added
Windows.Win32.System.Com.IMPLTYPEFLAGS.IMPLTYPEFLAG_FSOURCE added
Windows.Win32.System.Ole.ACTIVEOBJECT_FLAGS added
Windows.Win32.System.Ole.ACTIVEOBJECT_FLAGS.ACTIVEOBJECT_STRONG added
Windows.Win32.System.Ole.ACTIVEOBJECT_FLAGS.ACTIVEOBJECT_WEAK added
Windows.Win32.System.Ole.Apis.ACTIVEOBJECT_STRONG removed
Windows.Win32.System.Ole.Apis.ACTIVEOBJECT_WEAK removed
Windows.Win32.System.Ole.Apis.BZ_DISABLECANCELBUTTON removed
Windows.Win32.System.Ole.Apis.BZ_DISABLERETRYBUTTON removed
Windows.Win32.System.Ole.Apis.BZ_DISABLESWITCHTOBUTTON removed
Windows.Win32.System.Ole.Apis.BZ_NOTRESPONDINGDIALOG removed
Windows.Win32.System.Ole.Apis.CF_CONVERTONLY removed
Windows.Win32.System.Ole.Apis.CF_DISABLEACTIVATEAS removed
Windows.Win32.System.Ole.Apis.CF_DISABLEDISPLAYASICON removed
Windows.Win32.System.Ole.Apis.CF_HIDECHANGEICON removed
Windows.Win32.System.Ole.Apis.CF_SELECTACTIVATEAS removed
Windows.Win32.System.Ole.Apis.CF_SELECTCONVERTTO removed
Windows.Win32.System.Ole.Apis.CF_SETACTIVATEDEFAULT removed
Windows.Win32.System.Ole.Apis.CF_SETCONVERTDEFAULT removed
Windows.Win32.System.Ole.Apis.CF_SHOWHELPBUTTON removed
Windows.Win32.System.Ole.Apis.CIF_SELECTCURRENT removed
Windows.Win32.System.Ole.Apis.CIF_SELECTDEFAULT removed
Windows.Win32.System.Ole.Apis.CIF_SELECTFROMFILE removed
Windows.Win32.System.Ole.Apis.CIF_SHOWHELP removed
Windows.Win32.System.Ole.Apis.CIF_USEICONEXE removed
Windows.Win32.System.Ole.Apis.CSF_EXPLORER removed
Windows.Win32.System.Ole.Apis.CSF_ONLYGETSOURCE removed
Windows.Win32.System.Ole.Apis.CSF_SHOWHELP removed
Windows.Win32.System.Ole.Apis.CSF_VALIDSOURCE removed
Windows.Win32.System.Ole.Apis.ELF_DISABLECANCELLINK removed
Windows.Win32.System.Ole.Apis.ELF_DISABLECHANGESOURCE removed
Windows.Win32.System.Ole.Apis.ELF_DISABLEOPENSOURCE removed
Windows.Win32.System.Ole.Apis.ELF_DISABLEUPDATENOW removed
Windows.Win32.System.Ole.Apis.ELF_SHOWHELP removed
Windows.Win32.System.Ole.Apis.EMBDHLP_CREATENOW removed
Windows.Win32.System.Ole.Apis.EMBDHLP_DELAYCREATE removed
Windows.Win32.System.Ole.Apis.EMBDHLP_INPROC_HANDLER removed
Windows.Win32.System.Ole.Apis.EMBDHLP_INPROC_SERVER removed
Windows.Win32.System.Ole.Apis.fdexPropCanCall removed
Windows.Win32.System.Ole.Apis.fdexPropCanConstruct removed
Windows.Win32.System.Ole.Apis.fdexPropCanGet removed
Windows.Win32.System.Ole.Apis.fdexPropCannotCall removed
Windows.Win32.System.Ole.Apis.fdexPropCannotConstruct removed
Windows.Win32.System.Ole.Apis.fdexPropCannotGet removed
Windows.Win32.System.Ole.Apis.fdexPropCannotPut removed
Windows.Win32.System.Ole.Apis.fdexPropCannotPutRef removed
Windows.Win32.System.Ole.Apis.fdexPropCannotSourceEvents removed
Windows.Win32.System.Ole.Apis.fdexPropCanPut removed
Windows.Win32.System.Ole.Apis.fdexPropCanPutRef removed
Windows.Win32.System.Ole.Apis.fdexPropCanSourceEvents removed
Windows.Win32.System.Ole.Apis.fdexPropDynamicType removed
Windows.Win32.System.Ole.Apis.fdexPropNoSideEffects removed
Windows.Win32.System.Ole.Apis.IDLFLAG_FIN removed
Windows.Win32.System.Ole.Apis.IDLFLAG_FLCID removed
Windows.Win32.System.Ole.Apis.IDLFLAG_FOUT removed
Windows.Win32.System.Ole.Apis.IDLFLAG_FRETVAL removed
Windows.Win32.System.Ole.Apis.IDLFLAG_NONE removed
Windows.Win32.System.Ole.Apis.IMPLTYPEFLAG_FDEFAULT removed
Windows.Win32.System.Ole.Apis.IMPLTYPEFLAG_FDEFAULTVTABLE removed
Windows.Win32.System.Ole.Apis.IMPLTYPEFLAG_FRESTRICTED removed
Windows.Win32.System.Ole.Apis.IMPLTYPEFLAG_FSOURCE removed
Windows.Win32.System.Ole.Apis.IOF_CHECKDISPLAYASICON removed
Windows.Win32.System.Ole.Apis.IOF_CHECKLINK removed
Windows.Win32.System.Ole.Apis.IOF_CREATEFILEOBJECT removed
Windows.Win32.System.Ole.Apis.IOF_CREATELINKOBJECT removed
Windows.Win32.System.Ole.Apis.IOF_CREATENEWOBJECT removed
Windows.Win32.System.Ole.Apis.IOF_DISABLEDISPLAYASICON removed
Windows.Win32.System.Ole.Apis.IOF_DISABLELINK removed
Windows.Win32.System.Ole.Apis.IOF_HIDECHANGEICON removed
Windows.Win32.System.Ole.Apis.IOF_SELECTCREATECONTROL removed
Windows.Win32.System.Ole.Apis.IOF_SELECTCREATEFROMFILE removed
Windows.Win32.System.Ole.Apis.IOF_SELECTCREATENEW removed
Windows.Win32.System.Ole.Apis.IOF_SHOWHELP removed
Windows.Win32.System.Ole.Apis.IOF_SHOWINSERTCONTROL removed
Windows.Win32.System.Ole.Apis.IOF_VERIFYSERVERSEXIST removed
Windows.Win32.System.Ole.Apis.LP_COLOR removed
Windows.Win32.System.Ole.Apis.LP_DEFAULT removed
Windows.Win32.System.Ole.Apis.LP_MONOCHROME removed
Windows.Win32.System.Ole.Apis.LP_VGACOLOR removed
Windows.Win32.System.Ole.Apis.NUMPRS_CURRENCY removed
Windows.Win32.System.Ole.Apis.NUMPRS_DECIMAL removed
Windows.Win32.System.Ole.Apis.NUMPRS_EXPONENT removed
Windows.Win32.System.Ole.Apis.NUMPRS_HEX_OCT removed
Windows.Win32.System.Ole.Apis.NUMPRS_INEXACT removed
Windows.Win32.System.Ole.Apis.NUMPRS_LEADING_MINUS removed
Windows.Win32.System.Ole.Apis.NUMPRS_LEADING_PLUS removed
Windows.Win32.System.Ole.Apis.NUMPRS_LEADING_WHITE removed
Windows.Win32.System.Ole.Apis.NUMPRS_NEG removed
Windows.Win32.System.Ole.Apis.NUMPRS_PARENS removed
Windows.Win32.System.Ole.Apis.NUMPRS_STD removed
Windows.Win32.System.Ole.Apis.NUMPRS_THOUSANDS removed
Windows.Win32.System.Ole.Apis.NUMPRS_TRAILING_MINUS removed
Windows.Win32.System.Ole.Apis.NUMPRS_TRAILING_PLUS removed
Windows.Win32.System.Ole.Apis.NUMPRS_TRAILING_WHITE removed
Windows.Win32.System.Ole.Apis.NUMPRS_USE_ALL removed
Windows.Win32.System.Ole.Apis.OleCreate : renderopt...UInt32 => OLERENDER
Windows.Win32.System.Ole.Apis.OLECREATE_LEAVERUNNING removed
Windows.Win32.System.Ole.Apis.OleCreateEmbeddingHelper : flags...UInt32 => EMBDHLP_FLAGS
Windows.Win32.System.Ole.Apis.OleCreateEx : dwFlags...UInt32 => OLECREATE
Windows.Win32.System.Ole.Apis.OleCreateEx : renderopt...UInt32 => OLERENDER
Windows.Win32.System.Ole.Apis.OleCreateFromData : renderopt...UInt32 => OLERENDER
Windows.Win32.System.Ole.Apis.OleCreateFromDataEx : dwFlags...UInt32 => OLECREATE
Windows.Win32.System.Ole.Apis.OleCreateFromDataEx : renderopt...UInt32 => OLERENDER
Windows.Win32.System.Ole.Apis.OleCreateFromFile : renderopt...UInt32 => OLERENDER
Windows.Win32.System.Ole.Apis.OleCreateFromFileEx : dwFlags...UInt32 => OLECREATE
Windows.Win32.System.Ole.Apis.OleCreateFromFileEx : renderopt...UInt32 => OLERENDER
Windows.Win32.System.Ole.Apis.OleCreateLink : renderopt...UInt32 => OLERENDER
Windows.Win32.System.Ole.Apis.OleCreateLinkEx : dwFlags...UInt32 => OLECREATE
Windows.Win32.System.Ole.Apis.OleCreateLinkEx : renderopt...UInt32 => OLERENDER
Windows.Win32.System.Ole.Apis.OleCreateLinkFromData : renderopt...UInt32 => OLERENDER
Windows.Win32.System.Ole.Apis.OleCreateLinkFromDataEx : dwFlags...UInt32 => OLECREATE
Windows.Win32.System.Ole.Apis.OleCreateLinkFromDataEx : renderopt...UInt32 => OLERENDER
Windows.Win32.System.Ole.Apis.OleCreateLinkToFile : renderopt...UInt32 => OLERENDER
Windows.Win32.System.Ole.Apis.OleCreateLinkToFileEx : dwFlags...UInt32 => OLECREATE
Windows.Win32.System.Ole.Apis.OleCreateLinkToFileEx : renderopt...UInt32 => OLERENDER
Windows.Win32.System.Ole.Apis.OleCreateStaticFromData : renderopt...UInt32 => OLERENDER
Windows.Win32.System.Ole.Apis.OleLoadPictureEx : dwFlags...UInt32 => LOAD_PICTURE_FLAGS
Windows.Win32.System.Ole.Apis.OleLoadPictureFileEx : dwFlags...UInt32 => LOAD_PICTURE_FLAGS
Windows.Win32.System.Ole.Apis.OPF_DISABLECONVERT removed
Windows.Win32.System.Ole.Apis.OPF_NOFILLDEFAULT removed
Windows.Win32.System.Ole.Apis.OPF_OBJECTISLINK removed
Windows.Win32.System.Ole.Apis.OPF_SHOWHELP removed
Windows.Win32.System.Ole.Apis.PARAMFLAG_FHASCUSTDATA removed
Windows.Win32.System.Ole.Apis.PARAMFLAG_FHASDEFAULT removed
Windows.Win32.System.Ole.Apis.PARAMFLAG_FIN removed
Windows.Win32.System.Ole.Apis.PARAMFLAG_FLCID removed
Windows.Win32.System.Ole.Apis.PARAMFLAG_FOPT removed
Windows.Win32.System.Ole.Apis.PARAMFLAG_FOUT removed
Windows.Win32.System.Ole.Apis.PARAMFLAG_FRETVAL removed
Windows.Win32.System.Ole.Apis.PARAMFLAG_NONE removed
Windows.Win32.System.Ole.Apis.PICTYPE_BITMAP removed
Windows.Win32.System.Ole.Apis.PICTYPE_ENHMETAFILE removed
Windows.Win32.System.Ole.Apis.PICTYPE_ICON removed
Windows.Win32.System.Ole.Apis.PICTYPE_METAFILE removed
Windows.Win32.System.Ole.Apis.PICTYPE_NONE removed
Windows.Win32.System.Ole.Apis.PICTYPE_UNINITIALIZED removed
Windows.Win32.System.Ole.Apis.PSF_CHECKDISPLAYASICON removed
Windows.Win32.System.Ole.Apis.PSF_DISABLEDISPLAYASICON removed
Windows.Win32.System.Ole.Apis.PSF_HIDECHANGEICON removed
Windows.Win32.System.Ole.Apis.PSF_NOREFRESHDATAOBJECT removed
Windows.Win32.System.Ole.Apis.PSF_SELECTPASTE removed
Windows.Win32.System.Ole.Apis.PSF_SELECTPASTELINK removed
Windows.Win32.System.Ole.Apis.PSF_SHOWHELP removed
Windows.Win32.System.Ole.Apis.PSF_STAYONCLIPBOARDCHANGE removed
Windows.Win32.System.Ole.Apis.RegisterActiveObject : dwFlags...UInt32 => ACTIVEOBJECT_FLAGS
Windows.Win32.System.Ole.Apis.VarCmp : return...HRESULT => VARCMP
Windows.Win32.System.Ole.Apis.VARCMP_EQ removed
Windows.Win32.System.Ole.Apis.VARCMP_GT removed
Windows.Win32.System.Ole.Apis.VARCMP_LT removed
Windows.Win32.System.Ole.Apis.VARCMP_NULL removed
Windows.Win32.System.Ole.Apis.VarCyCmp : return...HRESULT => VARCMP
Windows.Win32.System.Ole.Apis.VarCyCmpR8 : return...HRESULT => VARCMP
Windows.Win32.System.Ole.Apis.VarDecCmp : return...HRESULT => VARCMP
Windows.Win32.System.Ole.Apis.VarDecCmpR8 : return...HRESULT => VARCMP
Windows.Win32.System.Ole.Apis.VarR4CmpR8 : return...HRESULT => VARCMP
Windows.Win32.System.Ole.Apis.VPF_DISABLERELATIVE removed
Windows.Win32.System.Ole.Apis.VPF_DISABLESCALE removed
Windows.Win32.System.Ole.Apis.VPF_SELECTRELATIVE removed
Windows.Win32.System.Ole.BUSY_DIALOG_FLAGS added
Windows.Win32.System.Ole.BUSY_DIALOG_FLAGS.BZ_DISABLECANCELBUTTON added
Windows.Win32.System.Ole.BUSY_DIALOG_FLAGS.BZ_DISABLERETRYBUTTON added
Windows.Win32.System.Ole.BUSY_DIALOG_FLAGS.BZ_DISABLESWITCHTOBUTTON added
Windows.Win32.System.Ole.BUSY_DIALOG_FLAGS.BZ_NOTRESPONDINGDIALOG added
Windows.Win32.System.Ole.CHANGE_ICON_FLAGS added
Windows.Win32.System.Ole.CHANGE_ICON_FLAGS.CIF_SELECTCURRENT added
Windows.Win32.System.Ole.CHANGE_ICON_FLAGS.CIF_SELECTDEFAULT added
Windows.Win32.System.Ole.CHANGE_ICON_FLAGS.CIF_SELECTFROMFILE added
Windows.Win32.System.Ole.CHANGE_ICON_FLAGS.CIF_SHOWHELP added
Windows.Win32.System.Ole.CHANGE_ICON_FLAGS.CIF_USEICONEXE added
Windows.Win32.System.Ole.CHANGE_SOURCE_FLAGS added
Windows.Win32.System.Ole.CHANGE_SOURCE_FLAGS.CSF_EXPLORER added
Windows.Win32.System.Ole.CHANGE_SOURCE_FLAGS.CSF_ONLYGETSOURCE added
Windows.Win32.System.Ole.CHANGE_SOURCE_FLAGS.CSF_SHOWHELP added
Windows.Win32.System.Ole.CHANGE_SOURCE_FLAGS.CSF_VALIDSOURCE added
Windows.Win32.System.Ole.EDIT_LINKS_FLAGS added
Windows.Win32.System.Ole.EDIT_LINKS_FLAGS.ELF_DISABLECANCELLINK added
Windows.Win32.System.Ole.EDIT_LINKS_FLAGS.ELF_DISABLECHANGESOURCE added
Windows.Win32.System.Ole.EDIT_LINKS_FLAGS.ELF_DISABLEOPENSOURCE added
Windows.Win32.System.Ole.EDIT_LINKS_FLAGS.ELF_DISABLEUPDATENOW added
Windows.Win32.System.Ole.EDIT_LINKS_FLAGS.ELF_SHOWHELP added
Windows.Win32.System.Ole.EMBDHLP_FLAGS added
Windows.Win32.System.Ole.EMBDHLP_FLAGS.EMBDHLP_CREATENOW added
Windows.Win32.System.Ole.EMBDHLP_FLAGS.EMBDHLP_DELAYCREATE added
Windows.Win32.System.Ole.EMBDHLP_FLAGS.EMBDHLP_INPROC_HANDLER added
Windows.Win32.System.Ole.EMBDHLP_FLAGS.EMBDHLP_INPROC_SERVER added
Windows.Win32.System.Ole.FDEX_PROP_FLAGS added
Windows.Win32.System.Ole.FDEX_PROP_FLAGS.fdexPropCanCall added
Windows.Win32.System.Ole.FDEX_PROP_FLAGS.fdexPropCanConstruct added
Windows.Win32.System.Ole.FDEX_PROP_FLAGS.fdexPropCanGet added
Windows.Win32.System.Ole.FDEX_PROP_FLAGS.fdexPropCannotCall added
Windows.Win32.System.Ole.FDEX_PROP_FLAGS.fdexPropCannotConstruct added
Windows.Win32.System.Ole.FDEX_PROP_FLAGS.fdexPropCannotGet added
Windows.Win32.System.Ole.FDEX_PROP_FLAGS.fdexPropCannotPut added
Windows.Win32.System.Ole.FDEX_PROP_FLAGS.fdexPropCannotPutRef added
Windows.Win32.System.Ole.FDEX_PROP_FLAGS.fdexPropCannotSourceEvents added
Windows.Win32.System.Ole.FDEX_PROP_FLAGS.fdexPropCanPut added
Windows.Win32.System.Ole.FDEX_PROP_FLAGS.fdexPropCanPutRef added
Windows.Win32.System.Ole.FDEX_PROP_FLAGS.fdexPropCanSourceEvents added
Windows.Win32.System.Ole.FDEX_PROP_FLAGS.fdexPropDynamicType added
Windows.Win32.System.Ole.FDEX_PROP_FLAGS.fdexPropNoSideEffects added
Windows.Win32.System.Ole.IDispatchEx.GetMemberProperties : pgrfdex...UInt32* => FDEX_PROP_FLAGS*
Windows.Win32.System.Ole.INSERT_OBJECT_FLAGS added
Windows.Win32.System.Ole.INSERT_OBJECT_FLAGS.IOF_CHECKDISPLAYASICON added
Windows.Win32.System.Ole.INSERT_OBJECT_FLAGS.IOF_CHECKLINK added
Windows.Win32.System.Ole.INSERT_OBJECT_FLAGS.IOF_CREATEFILEOBJECT added
Windows.Win32.System.Ole.INSERT_OBJECT_FLAGS.IOF_CREATELINKOBJECT added
Windows.Win32.System.Ole.INSERT_OBJECT_FLAGS.IOF_CREATENEWOBJECT added
Windows.Win32.System.Ole.INSERT_OBJECT_FLAGS.IOF_DISABLEDISPLAYASICON added
Windows.Win32.System.Ole.INSERT_OBJECT_FLAGS.IOF_DISABLELINK added
Windows.Win32.System.Ole.INSERT_OBJECT_FLAGS.IOF_HIDECHANGEICON added
Windows.Win32.System.Ole.INSERT_OBJECT_FLAGS.IOF_SELECTCREATECONTROL added
Windows.Win32.System.Ole.INSERT_OBJECT_FLAGS.IOF_SELECTCREATEFROMFILE added
Windows.Win32.System.Ole.INSERT_OBJECT_FLAGS.IOF_SELECTCREATENEW added
Windows.Win32.System.Ole.INSERT_OBJECT_FLAGS.IOF_SHOWHELP added
Windows.Win32.System.Ole.INSERT_OBJECT_FLAGS.IOF_SHOWINSERTCONTROL added
Windows.Win32.System.Ole.INSERT_OBJECT_FLAGS.IOF_VERIFYSERVERSEXIST added
Windows.Win32.System.Ole.LOAD_PICTURE_FLAGS added
Windows.Win32.System.Ole.LOAD_PICTURE_FLAGS.LP_COLOR added
Windows.Win32.System.Ole.LOAD_PICTURE_FLAGS.LP_DEFAULT added
Windows.Win32.System.Ole.LOAD_PICTURE_FLAGS.LP_MONOCHROME added
Windows.Win32.System.Ole.LOAD_PICTURE_FLAGS.LP_VGACOLOR added
Windows.Win32.System.Ole.NUMPARSE.dwInFlags...System.UInt32 => Windows.Win32.System.Ole.NUMPRS_FLAGS
Windows.Win32.System.Ole.NUMPARSE.dwOutFlags...System.UInt32 => Windows.Win32.System.Ole.NUMPRS_FLAGS
Windows.Win32.System.Ole.NUMPRS_FLAGS added
Windows.Win32.System.Ole.NUMPRS_FLAGS.NUMPRS_CURRENCY added
Windows.Win32.System.Ole.NUMPRS_FLAGS.NUMPRS_DECIMAL added
Windows.Win32.System.Ole.NUMPRS_FLAGS.NUMPRS_EXPONENT added
Windows.Win32.System.Ole.NUMPRS_FLAGS.NUMPRS_HEX_OCT added
Windows.Win32.System.Ole.NUMPRS_FLAGS.NUMPRS_INEXACT added
Windows.Win32.System.Ole.NUMPRS_FLAGS.NUMPRS_LEADING_MINUS added
Windows.Win32.System.Ole.NUMPRS_FLAGS.NUMPRS_LEADING_PLUS added
Windows.Win32.System.Ole.NUMPRS_FLAGS.NUMPRS_LEADING_WHITE added
Windows.Win32.System.Ole.NUMPRS_FLAGS.NUMPRS_NEG added
Windows.Win32.System.Ole.NUMPRS_FLAGS.NUMPRS_PARENS added
Windows.Win32.System.Ole.NUMPRS_FLAGS.NUMPRS_STD added
Windows.Win32.System.Ole.NUMPRS_FLAGS.NUMPRS_THOUSANDS added
Windows.Win32.System.Ole.NUMPRS_FLAGS.NUMPRS_TRAILING_MINUS added
Windows.Win32.System.Ole.NUMPRS_FLAGS.NUMPRS_TRAILING_PLUS added
Windows.Win32.System.Ole.NUMPRS_FLAGS.NUMPRS_TRAILING_WHITE added
Windows.Win32.System.Ole.NUMPRS_FLAGS.NUMPRS_USE_ALL added
Windows.Win32.System.Ole.OBJECT_PROPERTIES_FLAGS added
Windows.Win32.System.Ole.OBJECT_PROPERTIES_FLAGS.OPF_DISABLECONVERT added
Windows.Win32.System.Ole.OBJECT_PROPERTIES_FLAGS.OPF_NOFILLDEFAULT added
Windows.Win32.System.Ole.OBJECT_PROPERTIES_FLAGS.OPF_OBJECTISLINK added
Windows.Win32.System.Ole.OBJECT_PROPERTIES_FLAGS.OPF_SHOWHELP added
Windows.Win32.System.Ole.OLECREATE added
Windows.Win32.System.Ole.OLECREATE.OLECREATE_LEAVERUNNING added
Windows.Win32.System.Ole.OLECREATE.OLECREATE_ZERO added
Windows.Win32.System.Ole.OLEUICHANGEICONA.dwFlags...System.UInt32 => Windows.Win32.System.Ole.CHANGE_ICON_FLAGS
Windows.Win32.System.Ole.OLEUICHANGEICONW.dwFlags...System.UInt32 => Windows.Win32.System.Ole.CHANGE_ICON_FLAGS
Windows.Win32.System.Ole.OLEUICHANGESOURCEA.dwFlags...System.UInt32 => Windows.Win32.System.Ole.CHANGE_SOURCE_FLAGS
Windows.Win32.System.Ole.OLEUICHANGESOURCEW.dwFlags...System.UInt32 => Windows.Win32.System.Ole.CHANGE_SOURCE_FLAGS
Windows.Win32.System.Ole.OLEUICONVERTA.dwFlags...System.UInt32 => Windows.Win32.System.Ole.UI_CONVERT_FLAGS
Windows.Win32.System.Ole.OLEUICONVERTW.dwFlags...System.UInt32 => Windows.Win32.System.Ole.UI_CONVERT_FLAGS
Windows.Win32.System.Ole.OLEUIEDITLINKSA.dwFlags...System.UInt32 => Windows.Win32.System.Ole.EDIT_LINKS_FLAGS
Windows.Win32.System.Ole.OLEUIEDITLINKSW.dwFlags...System.UInt32 => Windows.Win32.System.Ole.EDIT_LINKS_FLAGS
Windows.Win32.System.Ole.OLEUIINSERTOBJECTA.dwFlags...System.UInt32 => Windows.Win32.System.Ole.INSERT_OBJECT_FLAGS
Windows.Win32.System.Ole.OLEUIINSERTOBJECTW.dwFlags...System.UInt32 => Windows.Win32.System.Ole.INSERT_OBJECT_FLAGS
Windows.Win32.System.Ole.OLEUIOBJECTPROPSA.dwFlags...System.UInt32 => Windows.Win32.System.Ole.OBJECT_PROPERTIES_FLAGS
Windows.Win32.System.Ole.OLEUIOBJECTPROPSW.dwFlags...System.UInt32 => Windows.Win32.System.Ole.OBJECT_PROPERTIES_FLAGS
Windows.Win32.System.Ole.OLEUIPASTESPECIALA.dwFlags...System.UInt32 => Windows.Win32.System.Ole.PASTE_SPECIAL_FLAGS
Windows.Win32.System.Ole.OLEUIPASTESPECIALW.dwFlags...System.UInt32 => Windows.Win32.System.Ole.PASTE_SPECIAL_FLAGS
Windows.Win32.System.Ole.OLEUIVIEWPROPSA.dwFlags...System.UInt32 => Windows.Win32.System.Ole.VIEW_OBJECT_PROPERTIES_FLAGS
Windows.Win32.System.Ole.OLEUIVIEWPROPSW.dwFlags...System.UInt32 => Windows.Win32.System.Ole.VIEW_OBJECT_PROPERTIES_FLAGS
Windows.Win32.System.Ole.PARAMDESC.wParamFlags...System.UInt16 => Windows.Win32.System.Ole.PARAMFLAGS
Windows.Win32.System.Ole.PARAMFLAGS added
Windows.Win32.System.Ole.PARAMFLAGS.PARAMFLAG_FHASCUSTDATA added
Windows.Win32.System.Ole.PARAMFLAGS.PARAMFLAG_FHASDEFAULT added
Windows.Win32.System.Ole.PARAMFLAGS.PARAMFLAG_FIN added
Windows.Win32.System.Ole.PARAMFLAGS.PARAMFLAG_FLCID added
Windows.Win32.System.Ole.PARAMFLAGS.PARAMFLAG_FOPT added
Windows.Win32.System.Ole.PARAMFLAGS.PARAMFLAG_FOUT added
Windows.Win32.System.Ole.PARAMFLAGS.PARAMFLAG_FRETVAL added
Windows.Win32.System.Ole.PARAMFLAGS.PARAMFLAG_NONE added
Windows.Win32.System.Ole.PASTE_SPECIAL_FLAGS added
Windows.Win32.System.Ole.PASTE_SPECIAL_FLAGS.PSF_CHECKDISPLAYASICON added
Windows.Win32.System.Ole.PASTE_SPECIAL_FLAGS.PSF_DISABLEDISPLAYASICON added
Windows.Win32.System.Ole.PASTE_SPECIAL_FLAGS.PSF_HIDECHANGEICON added
Windows.Win32.System.Ole.PASTE_SPECIAL_FLAGS.PSF_NOREFRESHDATAOBJECT added
Windows.Win32.System.Ole.PASTE_SPECIAL_FLAGS.PSF_SELECTPASTE added
Windows.Win32.System.Ole.PASTE_SPECIAL_FLAGS.PSF_SELECTPASTELINK added
Windows.Win32.System.Ole.PASTE_SPECIAL_FLAGS.PSF_SHOWHELP added
Windows.Win32.System.Ole.PASTE_SPECIAL_FLAGS.PSF_STAYONCLIPBOARDCHANGE added
Windows.Win32.System.Ole.PICTDESC.picType...System.UInt32 => Windows.Win32.System.Ole.PICTYPE
Windows.Win32.System.Ole.PICTYPE added
Windows.Win32.System.Ole.PICTYPE.PICTYPE_BITMAP added
Windows.Win32.System.Ole.PICTYPE.PICTYPE_ENHMETAFILE added
Windows.Win32.System.Ole.PICTYPE.PICTYPE_ICON added
Windows.Win32.System.Ole.PICTYPE.PICTYPE_METAFILE added
Windows.Win32.System.Ole.PICTYPE.PICTYPE_NONE added
Windows.Win32.System.Ole.PICTYPE.PICTYPE_UNINITIALIZED added
Windows.Win32.System.Ole.UI_CONVERT_FLAGS added
Windows.Win32.System.Ole.UI_CONVERT_FLAGS.CF_CONVERTONLY added
Windows.Win32.System.Ole.UI_CONVERT_FLAGS.CF_DISABLEACTIVATEAS added
Windows.Win32.System.Ole.UI_CONVERT_FLAGS.CF_DISABLEDISPLAYASICON added
Windows.Win32.System.Ole.UI_CONVERT_FLAGS.CF_HIDECHANGEICON added
Windows.Win32.System.Ole.UI_CONVERT_FLAGS.CF_SELECTACTIVATEAS added
Windows.Win32.System.Ole.UI_CONVERT_FLAGS.CF_SELECTCONVERTTO added
Windows.Win32.System.Ole.UI_CONVERT_FLAGS.CF_SETACTIVATEDEFAULT added
Windows.Win32.System.Ole.UI_CONVERT_FLAGS.CF_SETCONVERTDEFAULT added
Windows.Win32.System.Ole.UI_CONVERT_FLAGS.CF_SHOWHELPBUTTON added
Windows.Win32.System.Ole.VARCMP added
Windows.Win32.System.Ole.VARCMP.VARCMP_EQ added
Windows.Win32.System.Ole.VARCMP.VARCMP_GT added
Windows.Win32.System.Ole.VARCMP.VARCMP_LT added
Windows.Win32.System.Ole.VARCMP.VARCMP_NULL added
Windows.Win32.System.Ole.VIEW_OBJECT_PROPERTIES_FLAGS added
Windows.Win32.System.Ole.VIEW_OBJECT_PROPERTIES_FLAGS.VPF_DISABLERELATIVE added
Windows.Win32.System.Ole.VIEW_OBJECT_PROPERTIES_FLAGS.VPF_DISABLESCALE added
Windows.Win32.System.Ole.VIEW_OBJECT_PROPERTIES_FLAGS.VPF_SELECTRELATIVE added
```