### PR TITLE
Fix LOGFONTW/LOGFONTA

### DIFF
--- a/generation/WinSDK/enums.json
+++ b/generation/WinSDK/enums.json
@@ -7445,45 +7445,47 @@
   },
   {
     "name": "FONT_CLIP_PRECISION",
+    "type": "byte",
     "flags": true,
     "members": [
       {
-        "name": "CLIP_CHARACTER_PRECIS"
+        "name": "CLIP_DEFAULT_PRECIS",
+        "value": "0"
       },
       {
-        "name": "CLIP_DEFAULT_PRECIS"
+        "name": "CLIP_CHARACTER_PRECIS",
+        "value": "1"
       },
       {
-        "name": "CLIP_DFA_DISABLE"
+        "name": "CLIP_STROKE_PRECIS",
+        "value": "2"
       },
       {
-        "name": "CLIP_EMBEDDED"
+        "name": "CLIP_MASK",
+        "value": "0xf"
       },
       {
-        "name": "CLIP_LH_ANGLES"
+        "name": "CLIP_LH_ANGLES",
+        "value": "(1<<4)"
       },
       {
-        "name": "CLIP_MASK"
+        "name": "CLIP_TT_ALWAYS",
+        "value": "(2<<4)"
       },
       {
-        "name": "CLIP_DFA_OVERRIDE"
+        "name": "CLIP_DFA_DISABLE",
+        "value": "(4<<4)"
       },
       {
-        "name": "CLIP_STROKE_PRECIS"
+        "name": "CLIP_EMBEDDED",
+        "value": "(8<<4)"
       },
       {
-        "name": "CLIP_TT_ALWAYS"
+        "name": "CLIP_DFA_OVERRIDE",
+        "value": "(CLIP_DFA_DISABLE)"
       }
     ],
     "uses": [
-      {
-        "method": "CreateFontW",
-        "parameter": "iClipPrecision"
-      },
-      {
-        "method": "CreateFontA",
-        "parameter": "iClipPrecision"
-      },
       {
         "struct": "LOGFONTW",
         "field": "lfClipPrecision"
@@ -13233,47 +13235,54 @@
   },
   {
     "name": "FONT_OUTPUT_PRECISION",
+    "type": "byte",
     "members": [
       {
-        "name": "OUT_CHARACTER_PRECIS"
+        "name": "OUT_DEFAULT_PRECIS",
+        "value": "0"
       },
       {
-        "name": "OUT_DEFAULT_PRECIS"
+        "name": "OUT_STRING_PRECIS",
+        "value": "1"
       },
       {
-        "name": "OUT_DEVICE_PRECIS"
+        "name": "OUT_CHARACTER_PRECIS",
+        "value": "2"
       },
       {
-        "name": "OUT_OUTLINE_PRECIS"
+        "name": "OUT_STROKE_PRECIS",
+        "value": "3"
       },
       {
-        "name": "OUT_PS_ONLY_PRECIS"
+        "name": "OUT_TT_PRECIS",
+        "value": "4"
       },
       {
-        "name": "OUT_RASTER_PRECIS"
+        "name": "OUT_DEVICE_PRECIS",
+        "value": "5"
       },
       {
-        "name": "OUT_STRING_PRECIS"
+        "name": "OUT_RASTER_PRECIS",
+        "value": "6"
       },
       {
-        "name": "OUT_STROKE_PRECIS"
+        "name": "OUT_TT_ONLY_PRECIS",
+        "value": "7"
       },
       {
-        "name": "OUT_TT_ONLY_PRECIS"
+        "name": "OUT_OUTLINE_PRECIS",
+        "value": "8"
       },
       {
-        "name": "OUT_TT_PRECIS"
+        "name": "OUT_SCREEN_OUTLINE_PRECIS",
+        "value": "9"
+      },
+      {
+        "name": "OUT_PS_ONLY_PRECIS",
+        "value": "10"
       }
     ],
     "uses": [
-      {
-        "method": "CreateFontW",
-        "parameter": "iOutPrecision"
-      },
-      {
-        "method": "CreateFontA",
-        "parameter": "iOutPrecision"
-      },
       {
         "struct": "LOGFONTW",
         "field": "lfOutPrecision"
@@ -13292,30 +13301,11 @@
     },
     "members": [],
     "uses": [
-      {
-        "struct": "LOGFONTW",
-        "field": "lfWeight"
-      },
-      {
-        "struct": "LOGFONTA",
-        "field": "lfWeight"
-      },
-      {
-        "struct": "DLGTEMPLATEEX",
-        "field": "lfWeight"
-      },
-      {
-        "method": "put_Weight",
-        "parameter": "weight"
-      },
-      {
-        "method": "get_Weight",
-        "parameter": "pWeight"
-      }
     ]
   },
   {
     "name": "FONT_CHARSET",
+    "type": "byte",
     "members": [
       {
         "name": "ANSI_CHARSET",
@@ -13401,6 +13391,10 @@
     "uses": [
       {
         "struct": "LOGFONTW",
+        "field": "lfCharSet"
+      },
+      {
+        "struct": "LOGFONTA",
         "field": "lfCharSet"
       },
       {
@@ -14038,35 +14032,34 @@
   },
   {
     "name": "FONT_QUALITY",
+    "type": "byte",
     "members": [
       {
-        "name": "ANTIALIASED_QUALITY"
+        "name": "DEFAULT_QUALITY",
+        "value": "0"
       },
       {
-        "name": "CLEARTYPE_QUALITY"
+        "name": "DRAFT_QUALITY",
+        "value": "1"
       },
       {
-        "name": "DEFAULT_QUALITY"
+        "name": "PROOF_QUALITY",
+        "value": "2"
       },
       {
-        "name": "DRAFT_QUALITY"
+        "name": "NONANTIALIASED_QUALITY",
+        "value": "3"
       },
       {
-        "name": "NONANTIALIASED_QUALITY"
+        "name": "ANTIALIASED_QUALITY",
+        "value": "4"
       },
       {
-        "name": "PROOF_QUALITY"
+        "name": "CLEARTYPE_QUALITY",
+        "value": "5"
       }
     ],
     "uses": [
-      {
-        "method": "CreateFontA",
-        "parameter": "iQuality"
-      },
-      {
-        "method": "CreateFontW",
-        "parameter": "iQuality"
-      },
       {
         "struct": "LOGFONTW",
         "field": "lfQuality"
@@ -17649,53 +17642,53 @@
     ]
   },
   {
-    "name": "FONT_PITCH_AND_FAMILY",
+    "name": "FONT_PITCH",
+    "namespace": "Windows.Win32.Graphics.Gdi",
+    "type": "byte",
     "members": [
       {
-        "name": "FF_DECORATIVE"
+        "name": "DEFAULT_PITCH"
       },
       {
-        "name": "FF_DONTCARE"
+        "name": "FIXED_PITCH"
       },
       {
-        "name": "FF_MODERN"
-      },
-      {
-        "name": "FF_ROMAN"
-      },
-      {
-        "name": "FF_SCRIPT"
-      },
-      {
-        "name": "FF_SWISS"
+        "name": "VARIABLE_PITCH"
       }
     ],
-    "uses": [
+    "uses": []
+  },
+  {
+    "name": "FONT_FAMILY",
+    "namespace": "Windows.Win32.Graphics.Gdi",
+    "type": "byte",
+    "members": [
       {
-        "method": "CreateFontW",
-        "parameter": "iPitchAndFamily"
+        "name": "FF_DECORATIVE",
+        "value": "(5<<4)"
       },
       {
-        "method": "CreateFontA",
-        "parameter": "iPitchAndFamily"
+        "name": "FF_DONTCARE",
+        "value": "(0<<4)"
       },
       {
-        "struct": "LOGFONTW",
-        "field": "lfPitchAndFamily"
+        "name": "FF_MODERN",
+        "value": "(3<<4)"
       },
       {
-        "method": "LOGFONTA",
-        "parameter": "lfPitchAndFamily"
+        "name": "FF_ROMAN",
+        "value": "(1<<4)"
       },
       {
-        "method": "CHARFORMATA",
-        "parameter": "bPitchAndFamily"
+        "name": "FF_SCRIPT",
+        "value": "(4<<4)"
       },
       {
-        "method": "CHARFORMATW",
-        "parameter": "bPitchAndFamily"
+        "name": "FF_SWISS",
+        "value": "(2<<4)"
       }
-    ]
+    ],
+    "uses": []
   },
   {
     "name": "WINDOW_DISPLAY_AFFINITY",

--- a/scripts/ChangesSinceLastRelease.txt
+++ b/scripts/ChangesSinceLastRelease.txt
@@ -368,3 +368,79 @@ Windows.Win32.UI.Magnification.Apis.MW_FILTERMODE_INCLUDE removed
 Windows.Win32.UI.Magnification.MW_FILTERMODE added
 Windows.Win32.UI.Magnification.MW_FILTERMODE.MW_FILTERMODE_EXCLUDE added
 Windows.Win32.UI.Magnification.MW_FILTERMODE.MW_FILTERMODE_INCLUDE added
+# LOGFONT enum changes
+Windows.Win32.Graphics.Gdi.Apis.CreateFontA : iClipPrecision...FONT_CLIP_PRECISION => UInt32
+Windows.Win32.Graphics.Gdi.Apis.CreateFontA : iOutPrecision...FONT_OUTPUT_PRECISION => UInt32
+Windows.Win32.Graphics.Gdi.Apis.CreateFontA : iPitchAndFamily...FONT_PITCH_AND_FAMILY => UInt32
+Windows.Win32.Graphics.Gdi.Apis.CreateFontA : iQuality...FONT_QUALITY => UInt32
+Windows.Win32.Graphics.Gdi.Apis.CreateFontW : iClipPrecision...FONT_CLIP_PRECISION => UInt32
+Windows.Win32.Graphics.Gdi.Apis.CreateFontW : iOutPrecision...FONT_OUTPUT_PRECISION => UInt32
+Windows.Win32.Graphics.Gdi.Apis.CreateFontW : iPitchAndFamily...FONT_PITCH_AND_FAMILY => UInt32
+Windows.Win32.Graphics.Gdi.Apis.CreateFontW : iQuality...FONT_QUALITY => UInt32
+Windows.Win32.Graphics.Gdi.Apis.DEFAULT_PITCH removed
+Windows.Win32.Graphics.Gdi.Apis.FIXED_PITCH removed
+Windows.Win32.Graphics.Gdi.Apis.OUT_SCREEN_OUTLINE_PRECIS removed
+Windows.Win32.Graphics.Gdi.Apis.VARIABLE_PITCH removed
+Windows.Win32.Graphics.Gdi.FONT_CHARSET.value__...System.UInt32 => System.Byte
+Windows.Win32.Graphics.Gdi.FONT_CLIP_PRECISION.CLIP_DFA_OVERRIDE added
+Windows.Win32.Graphics.Gdi.FONT_CLIP_PRECISION.value__...System.UInt32 => System.Byte
+Windows.Win32.Graphics.Gdi.FONT_FAMILY added
+Windows.Win32.Graphics.Gdi.FONT_FAMILY.FF_DECORATIVE added
+Windows.Win32.Graphics.Gdi.FONT_FAMILY.FF_DONTCARE added
+Windows.Win32.Graphics.Gdi.FONT_FAMILY.FF_MODERN added
+Windows.Win32.Graphics.Gdi.FONT_FAMILY.FF_ROMAN added
+Windows.Win32.Graphics.Gdi.FONT_FAMILY.FF_SCRIPT added
+Windows.Win32.Graphics.Gdi.FONT_FAMILY.FF_SWISS added
+Windows.Win32.Graphics.Gdi.FONT_OUTPUT_PRECISION.OUT_SCREEN_OUTLINE_PRECIS added
+Windows.Win32.Graphics.Gdi.FONT_OUTPUT_PRECISION.value__...System.UInt32 => System.Byte
+Windows.Win32.Graphics.Gdi.FONT_PITCH added
+Windows.Win32.Graphics.Gdi.FONT_PITCH_AND_FAMILY removed
+Windows.Win32.Graphics.Gdi.FONT_PITCH_AND_FAMILY.FF_DECORATIVE removed
+Windows.Win32.Graphics.Gdi.FONT_PITCH_AND_FAMILY.FF_DONTCARE removed
+Windows.Win32.Graphics.Gdi.FONT_PITCH_AND_FAMILY.FF_MODERN removed
+Windows.Win32.Graphics.Gdi.FONT_PITCH_AND_FAMILY.FF_ROMAN removed
+Windows.Win32.Graphics.Gdi.FONT_PITCH_AND_FAMILY.FF_SCRIPT removed
+Windows.Win32.Graphics.Gdi.FONT_PITCH_AND_FAMILY.FF_SWISS removed
+Windows.Win32.Graphics.Gdi.FONT_PITCH.DEFAULT_PITCH added
+Windows.Win32.Graphics.Gdi.FONT_PITCH.FIXED_PITCH added
+Windows.Win32.Graphics.Gdi.FONT_PITCH.VARIABLE_PITCH added
+Windows.Win32.Graphics.Gdi.FONT_QUALITY.value__...System.UInt32 => System.Byte
+Windows.Win32.Graphics.Gdi.FONT_WEIGHT removed
+Windows.Win32.Graphics.Gdi.FONT_WEIGHT.FW_BLACK removed
+Windows.Win32.Graphics.Gdi.FONT_WEIGHT.FW_BOLD removed
+Windows.Win32.Graphics.Gdi.FONT_WEIGHT.FW_DEMIBOLD removed
+Windows.Win32.Graphics.Gdi.FONT_WEIGHT.FW_DONTCARE removed
+Windows.Win32.Graphics.Gdi.FONT_WEIGHT.FW_EXTRABOLD removed
+Windows.Win32.Graphics.Gdi.FONT_WEIGHT.FW_EXTRALIGHT removed
+Windows.Win32.Graphics.Gdi.FONT_WEIGHT.FW_HEAVY removed
+Windows.Win32.Graphics.Gdi.FONT_WEIGHT.FW_LIGHT removed
+Windows.Win32.Graphics.Gdi.FONT_WEIGHT.FW_MEDIUM removed
+Windows.Win32.Graphics.Gdi.FONT_WEIGHT.FW_NORMAL removed
+Windows.Win32.Graphics.Gdi.FONT_WEIGHT.FW_REGULAR removed
+Windows.Win32.Graphics.Gdi.FONT_WEIGHT.FW_SEMIBOLD removed
+Windows.Win32.Graphics.Gdi.FONT_WEIGHT.FW_THIN removed
+Windows.Win32.Graphics.Gdi.FONT_WEIGHT.FW_ULTRABOLD removed
+Windows.Win32.Graphics.Gdi.FONT_WEIGHT.FW_ULTRALIGHT removed
+Windows.Win32.Graphics.Gdi.LOGFONTA.lfCharSet...System.Byte => Windows.Win32.Graphics.Gdi.FONT_CHARSET
+Windows.Win32.Graphics.Gdi.LOGFONTA.lfPitchAndFamily...Windows.Win32.Graphics.Gdi.FONT_PITCH_AND_FAMILY => System.Byte
+Windows.Win32.Graphics.Gdi.LOGFONTA.lfWeight...Windows.Win32.Graphics.Gdi.FONT_WEIGHT => System.Int32
+Windows.Win32.Graphics.Gdi.LOGFONTW.lfPitchAndFamily...Windows.Win32.Graphics.Gdi.FONT_PITCH_AND_FAMILY => System.Byte
+Windows.Win32.Graphics.Gdi.LOGFONTW.lfWeight...Windows.Win32.Graphics.Gdi.FONT_WEIGHT => System.Int32
+Windows.Win32.System.SystemServices.FONT_WEIGHT added
+Windows.Win32.System.SystemServices.FONT_WEIGHT.FW_BLACK added
+Windows.Win32.System.SystemServices.FONT_WEIGHT.FW_BOLD added
+Windows.Win32.System.SystemServices.FONT_WEIGHT.FW_DEMIBOLD added
+Windows.Win32.System.SystemServices.FONT_WEIGHT.FW_DONTCARE added
+Windows.Win32.System.SystemServices.FONT_WEIGHT.FW_EXTRABOLD added
+Windows.Win32.System.SystemServices.FONT_WEIGHT.FW_EXTRALIGHT added
+Windows.Win32.System.SystemServices.FONT_WEIGHT.FW_HEAVY added
+Windows.Win32.System.SystemServices.FONT_WEIGHT.FW_LIGHT added
+Windows.Win32.System.SystemServices.FONT_WEIGHT.FW_MEDIUM added
+Windows.Win32.System.SystemServices.FONT_WEIGHT.FW_NORMAL added
+Windows.Win32.System.SystemServices.FONT_WEIGHT.FW_REGULAR added
+Windows.Win32.System.SystemServices.FONT_WEIGHT.FW_SEMIBOLD added
+Windows.Win32.System.SystemServices.FONT_WEIGHT.FW_THIN added
+Windows.Win32.System.SystemServices.FONT_WEIGHT.FW_ULTRABOLD added
+Windows.Win32.System.SystemServices.FONT_WEIGHT.FW_ULTRALIGHT added
+Windows.Win32.UI.Controls.RichEdit.CHARFORMATA.bPitchAndFamily...Windows.Win32.Graphics.Gdi.FONT_PITCH_AND_FAMILY => System.Byte
+Windows.Win32.UI.Controls.RichEdit.CHARFORMATW.bPitchAndFamily...Windows.Win32.Graphics.Gdi.FONT_PITCH_AND_FAMILY => System.Byte


### PR DESCRIPTION
Fixes: #1213

```
Windows.Win32.Graphics.Gdi.Apis.CreateFontA : iClipPrecision...FONT_CLIP_PRECISION => UInt32
Windows.Win32.Graphics.Gdi.Apis.CreateFontA : iOutPrecision...FONT_OUTPUT_PRECISION => UInt32
Windows.Win32.Graphics.Gdi.Apis.CreateFontA : iPitchAndFamily...FONT_PITCH_AND_FAMILY => UInt32
Windows.Win32.Graphics.Gdi.Apis.CreateFontA : iQuality...FONT_QUALITY => UInt32
Windows.Win32.Graphics.Gdi.Apis.CreateFontW : iClipPrecision...FONT_CLIP_PRECISION => UInt32
Windows.Win32.Graphics.Gdi.Apis.CreateFontW : iOutPrecision...FONT_OUTPUT_PRECISION => UInt32
Windows.Win32.Graphics.Gdi.Apis.CreateFontW : iPitchAndFamily...FONT_PITCH_AND_FAMILY => UInt32
Windows.Win32.Graphics.Gdi.Apis.CreateFontW : iQuality...FONT_QUALITY => UInt32
Windows.Win32.Graphics.Gdi.Apis.DEFAULT_PITCH removed
Windows.Win32.Graphics.Gdi.Apis.FIXED_PITCH removed
Windows.Win32.Graphics.Gdi.Apis.OUT_SCREEN_OUTLINE_PRECIS removed
Windows.Win32.Graphics.Gdi.Apis.VARIABLE_PITCH removed
Windows.Win32.Graphics.Gdi.FONT_CHARSET.value__...System.UInt32 => System.Byte
Windows.Win32.Graphics.Gdi.FONT_CLIP_PRECISION.CLIP_DFA_OVERRIDE added
Windows.Win32.Graphics.Gdi.FONT_CLIP_PRECISION.value__...System.UInt32 => System.Byte
Windows.Win32.Graphics.Gdi.FONT_FAMILY added
Windows.Win32.Graphics.Gdi.FONT_FAMILY.FF_DECORATIVE added
Windows.Win32.Graphics.Gdi.FONT_FAMILY.FF_DONTCARE added
Windows.Win32.Graphics.Gdi.FONT_FAMILY.FF_MODERN added
Windows.Win32.Graphics.Gdi.FONT_FAMILY.FF_ROMAN added
Windows.Win32.Graphics.Gdi.FONT_FAMILY.FF_SCRIPT added
Windows.Win32.Graphics.Gdi.FONT_FAMILY.FF_SWISS added
Windows.Win32.Graphics.Gdi.FONT_OUTPUT_PRECISION.OUT_SCREEN_OUTLINE_PRECIS added
Windows.Win32.Graphics.Gdi.FONT_OUTPUT_PRECISION.value__...System.UInt32 => System.Byte
Windows.Win32.Graphics.Gdi.FONT_PITCH added
Windows.Win32.Graphics.Gdi.FONT_PITCH_AND_FAMILY removed
Windows.Win32.Graphics.Gdi.FONT_PITCH_AND_FAMILY.FF_DECORATIVE removed
Windows.Win32.Graphics.Gdi.FONT_PITCH_AND_FAMILY.FF_DONTCARE removed
Windows.Win32.Graphics.Gdi.FONT_PITCH_AND_FAMILY.FF_MODERN removed
Windows.Win32.Graphics.Gdi.FONT_PITCH_AND_FAMILY.FF_ROMAN removed
Windows.Win32.Graphics.Gdi.FONT_PITCH_AND_FAMILY.FF_SCRIPT removed
Windows.Win32.Graphics.Gdi.FONT_PITCH_AND_FAMILY.FF_SWISS removed
Windows.Win32.Graphics.Gdi.FONT_PITCH.DEFAULT_PITCH added
Windows.Win32.Graphics.Gdi.FONT_PITCH.FIXED_PITCH added
Windows.Win32.Graphics.Gdi.FONT_PITCH.VARIABLE_PITCH added
Windows.Win32.Graphics.Gdi.FONT_QUALITY.value__...System.UInt32 => System.Byte
Windows.Win32.Graphics.Gdi.FONT_WEIGHT removed
Windows.Win32.Graphics.Gdi.FONT_WEIGHT.FW_BLACK removed
Windows.Win32.Graphics.Gdi.FONT_WEIGHT.FW_BOLD removed
Windows.Win32.Graphics.Gdi.FONT_WEIGHT.FW_DEMIBOLD removed
Windows.Win32.Graphics.Gdi.FONT_WEIGHT.FW_DONTCARE removed
Windows.Win32.Graphics.Gdi.FONT_WEIGHT.FW_EXTRABOLD removed
Windows.Win32.Graphics.Gdi.FONT_WEIGHT.FW_EXTRALIGHT removed
Windows.Win32.Graphics.Gdi.FONT_WEIGHT.FW_HEAVY removed
Windows.Win32.Graphics.Gdi.FONT_WEIGHT.FW_LIGHT removed
Windows.Win32.Graphics.Gdi.FONT_WEIGHT.FW_MEDIUM removed
Windows.Win32.Graphics.Gdi.FONT_WEIGHT.FW_NORMAL removed
Windows.Win32.Graphics.Gdi.FONT_WEIGHT.FW_REGULAR removed
Windows.Win32.Graphics.Gdi.FONT_WEIGHT.FW_SEMIBOLD removed
Windows.Win32.Graphics.Gdi.FONT_WEIGHT.FW_THIN removed
Windows.Win32.Graphics.Gdi.FONT_WEIGHT.FW_ULTRABOLD removed
Windows.Win32.Graphics.Gdi.FONT_WEIGHT.FW_ULTRALIGHT removed
Windows.Win32.Graphics.Gdi.LOGFONTA.lfCharSet...System.Byte => Windows.Win32.Graphics.Gdi.FONT_CHARSET
Windows.Win32.Graphics.Gdi.LOGFONTA.lfPitchAndFamily...Windows.Win32.Graphics.Gdi.FONT_PITCH_AND_FAMILY => System.Byte
Windows.Win32.Graphics.Gdi.LOGFONTA.lfWeight...Windows.Win32.Graphics.Gdi.FONT_WEIGHT => System.Int32
Windows.Win32.Graphics.Gdi.LOGFONTW.lfPitchAndFamily...Windows.Win32.Graphics.Gdi.FONT_PITCH_AND_FAMILY => System.Byte
Windows.Win32.Graphics.Gdi.LOGFONTW.lfWeight...Windows.Win32.Graphics.Gdi.FONT_WEIGHT => System.Int32
Windows.Win32.System.SystemServices.FONT_WEIGHT added
Windows.Win32.System.SystemServices.FONT_WEIGHT.FW_BLACK added
Windows.Win32.System.SystemServices.FONT_WEIGHT.FW_BOLD added
Windows.Win32.System.SystemServices.FONT_WEIGHT.FW_DEMIBOLD added
Windows.Win32.System.SystemServices.FONT_WEIGHT.FW_DONTCARE added
Windows.Win32.System.SystemServices.FONT_WEIGHT.FW_EXTRABOLD added
Windows.Win32.System.SystemServices.FONT_WEIGHT.FW_EXTRALIGHT added
Windows.Win32.System.SystemServices.FONT_WEIGHT.FW_HEAVY added
Windows.Win32.System.SystemServices.FONT_WEIGHT.FW_LIGHT added
Windows.Win32.System.SystemServices.FONT_WEIGHT.FW_MEDIUM added
Windows.Win32.System.SystemServices.FONT_WEIGHT.FW_NORMAL added
Windows.Win32.System.SystemServices.FONT_WEIGHT.FW_REGULAR added
Windows.Win32.System.SystemServices.FONT_WEIGHT.FW_SEMIBOLD added
Windows.Win32.System.SystemServices.FONT_WEIGHT.FW_THIN added
Windows.Win32.System.SystemServices.FONT_WEIGHT.FW_ULTRABOLD added
Windows.Win32.System.SystemServices.FONT_WEIGHT.FW_ULTRALIGHT added
Windows.Win32.UI.Controls.RichEdit.CHARFORMATA.bPitchAndFamily...Windows.Win32.Graphics.Gdi.FONT_PITCH_AND_FAMILY => System.Byte
Windows.Win32.UI.Controls.RichEdit.CHARFORMATW.bPitchAndFamily...Windows.Win32.Graphics.Gdi.FONT_PITCH_AND_FAMILY => System.Byte
```