### PR TITLE
Logging improvements

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,7 @@ jobs:
       targetType: inline
       script: |
         .\scripts\Install-DotNetTool.ps1 -Name nbgv
-        nbgv cloud      
+        nbgv cloud
 
   - task: PowerShell@2
     displayName: GenerateMetadataSource.ps1 - x64
@@ -298,6 +298,11 @@ jobs:
       MaxConcurrency: '50'
       MaxRetryAttempts: '2'
     condition: and(succeeded(), eq(variables['SignFiles'], 'true'), ne(variables['Build.Reason'], 'PullRequest'))
+
+  - publish: bin/logs
+    artifact: build_logs
+    displayName: 📢 Publish build logs
+    condition: always()
 
   - task: PublishPipelineArtifact@1
     displayName: 'Publish NuGet packages to pipeline artifacts'

--- a/scripts/AddRemapsFromApiCsv.ps1
+++ b/scripts/AddRemapsFromApiCsv.ps1
@@ -7,7 +7,7 @@ param
 
 if (!(Test-Path -path $apiCsvFileName))
 {
-    Write-Output "Error: Couldn't find csv file $apiCsvFileName."
+    Write-Error "Couldn't find csv file $apiCsvFileName."
     exit -1
 }
 
@@ -40,4 +40,3 @@ foreach ($item in $apiData)
 }
 
 Add-Content -Path $baseRemapRsp -Value $sb.ToString()
-

--- a/scripts/BuildMetadataBin.ps1
+++ b/scripts/BuildMetadataBin.ps1
@@ -54,5 +54,5 @@ else
     $configuration = "Release"
 }
 
-dotnet build "$windowsWin32ProjectRoot" -c $configuration -t:EmitWinmd -p:WinmdVersion=$assemblyVersion -p:OutputWinmd=$outputWinmdFileName -p:SkipScraping=$skipScraping
+dotnet build "$windowsWin32ProjectRoot" -c $configuration -t:EmitWinmd -p:WinmdVersion=$assemblyVersion -p:OutputWinmd=$outputWinmdFileName -p:SkipScraping=$skipScraping "-bl:$PSScriptRoot\..\bin\logs\BuildMetadataBin.binlog"
 ThrowOnNativeProcessError

--- a/scripts/BuildMetadataBin.ps1
+++ b/scripts/BuildMetadataBin.ps1
@@ -35,8 +35,8 @@ $arch = "crossarch"
 
 $outputWinmdFileName = Get-OutputWinmdFileName -Arch $arch
 
-Write-Output "`n"
-Write-Output "`e[36m*** Creating $outputWinmdFileName...`e[0m"
+Write-Host "`n"
+Write-Host "*** Creating $outputWinmdFileName..." -ForegroundColor Blue
 
 $skipScraping = "false"
 

--- a/scripts/CommonUtils.ps1
+++ b/scripts/CommonUtils.ps1
@@ -65,7 +65,7 @@ function Install-BuildTools
         & dotnet clean "$rootDir\buildtools"
     }
 
-    & dotnet build "$rootDir\buildtools" -c Release
+    & dotnet build "$rootDir\buildtools" -c Release "-bl:$PSScriptRoot\..\bin\logs\buildtools.binlog"
     ThrowOnNativeProcessError
 
     Install-VsDevShell

--- a/scripts/CommonUtils.ps1
+++ b/scripts/CommonUtils.ps1
@@ -22,7 +22,7 @@ $ErrorActionPreference = "Stop"
 function ThrowOnNativeProcessError
 {
     if (-not $?)
-    {   
+    {
         $var = $?
         throw "Call to process exited with error"
     }
@@ -139,7 +139,7 @@ function Invoke-PrepLibMappingsFile
         $libPkgPath = Get-WinSdkCppX64PkgPath
         $libDirectory = "$libPkgPath\c\um\x64"
 
-        Write-Output "Creating lib mapping file: $libMappingOutputFileName using $libDirectory"
+        Write-Host "Creating lib mapping file: $libMappingOutputFileName using $libDirectory"
 
         & $PSScriptRoot\CreateProcLibMappingForAllLibs.ps1 -libDirectory $libDirectory -outputFileName $libMappingOutputFileName
     }
@@ -152,14 +152,14 @@ function Invoke-RecompileMidlHeaders
         $zipFile = "$scraperDir\RecompiledIdlHeaders.zip"
         if (Test-Path $zipFile)
         {
-            Write-Output "Unzipping recompiled headers from $zipFile..."
+            Write-Host "Unzipping recompiled headers from $zipFile..."
             Expand-Archive $zipFile -DestinationPath $artifactsDir
             return
         }
 
         & $PSScriptRoot\RecompileIdlFilesForScraping.ps1 -sdkBinDir $sdkBinDir -includeDir $recompiledIdlHeadersDir
 
-        Write-Output "Compressing headers to $zipFile..."
+        Write-Host "Compressing headers to $zipFile..."
         Compress-Archive -Path $recompiledIdlHeadersDir -DestinationPath $zipFile
     }
 }
@@ -199,9 +199,9 @@ function Install-VsDevShell
         $currentDir = Get-Location
         $installDir = & "$PSScriptRoot\Get-VSPath.ps1"
         $vsInstallScript = Join-Path $installDir "Common7\Tools\Launch-VsDevShell.ps1"
-    
+
         & $vsInstallScript
-    
+
         Set-Location $currentDir
     }
 }

--- a/scripts/ConvertMidlAttributesToSalAnnotations.ps1
+++ b/scripts/ConvertMidlAttributesToSalAnnotations.ps1
@@ -12,7 +12,7 @@ param
 
 if (!(Test-Path -path $inputFileName))
 {
-    Write-Output "Error: Couldn't find $inputFileName."
+    Write-Error "Couldn't find $inputFileName."
     exit -1
 }
 
@@ -110,7 +110,7 @@ foreach ($line in $srcLines)
             }
             elseif ($out)
             {
-                $annotation = "_Out_"    
+                $annotation = "_Out_"
                 $ptrOp = "writes_"
             }
 
@@ -165,7 +165,7 @@ foreach ($line in $srcLines)
                 # lists in this line
                 $beginLookAt = $match.Groups[0].Index + $match.Groups[0].Length + $annotationAttr.Length
             }
-            else 
+            else
             {
                 break
             }

--- a/scripts/CreateApiInfoCsv.ps1
+++ b/scripts/CreateApiInfoCsv.ps1
@@ -1,4 +1,4 @@
-Write-Output "Name,Title,Header,TechRoot"
+Write-Host "Name,Title,Header,TechRoot"
 
 foreach ($funcFile in Get-ChildItem "$sdkApiPath\n*.md" -r)
 {
@@ -12,7 +12,7 @@ foreach ($funcFile in Get-ChildItem "$sdkApiPath\n*.md" -r)
         foreach ($match in $matchInfo.Matches)
         {
             foreach ($group in $match.Groups)
-            { 
+            {
                 if ($group.Success)
                 {
                     switch ($group.Name)
@@ -29,6 +29,6 @@ foreach ($funcFile in Get-ChildItem "$sdkApiPath\n*.md" -r)
 
     if (!$funcName.Contains("."))
     {
-        Write-Output "$funcName,$title,$reqHeader,$techRoot"
+        Write-Host "$funcName,$title,$reqHeader,$techRoot"
     }
 }

--- a/scripts/CreateNameToNamespaceMappings.ps1
+++ b/scripts/CreateNameToNamespaceMappings.ps1
@@ -11,13 +11,13 @@ param
 
 if (!(Test-Path -path $apiCsvFileName))
 {
-    Write-Output "Error: Couldn't find csv file $apiCsvFileName."
+    Write-Error "Couldn't find csv file $apiCsvFileName."
     exit -1
 }
 
 if (!(Test-Path -path $techRootToNamespaceMappingsFileName))
 {
-    Write-Output "Error: Couldn't find csv file $techRootToNamespaceMappingsFileName."
+    Write-Error "Couldn't find csv file $techRootToNamespaceMappingsFileName."
     exit -1
 }
 

--- a/scripts/CreateProcLibMappingForAllLibs.ps1
+++ b/scripts/CreateProcLibMappingForAllLibs.ps1
@@ -14,7 +14,7 @@ $libDirectory = "$libPkgPath\c\um\x64"
 
 if (!(Test-Path -path $libDirectory))
 {
-    Write-Output "Error: Couldn't find $libDirectory."
+    Write-Error "Couldn't find $libDirectory."
     exit -1
 }
 

--- a/scripts/CreateSupportedOSPlatformRsp.ps1
+++ b/scripts/CreateSupportedOSPlatformRsp.ps1
@@ -50,13 +50,13 @@ function Remove-Prefix
     {
         return $match.Groups[1].Value
     }
-    else 
+    else
     {
-        return $text    
+        return $text
     }
 }
 
-try 
+try
 {
     $stream = [System.IO.StreamWriter] $outputFileName
     $stream.WriteLine("--with-attribute")
@@ -66,7 +66,7 @@ try
         $name = ""
         $version = ""
         $serverVersion = ""
-    
+
         $fileName = [System.IO.Path]::GetFileName($funcFile.FullName)
         if ($fileName -eq "nf-ktmw32-committransaction.md")
         {
@@ -117,12 +117,12 @@ try
                     {
                         $versionName += "." + $match.Groups[2]
                     }
-        
+
                     if ($versionMap.ContainsKey($versionName))
                     {
                         $fixedVersion = $versionMap[$versionName]
                     }
-                    else 
+                    else
                     {
                         Write-Error "Failed to lookup windows version: $version"
                     }
@@ -144,11 +144,11 @@ try
 
                     if ([string]::IsNullOrEmpty($fixedVersion))
                     {
-                        Write-Output "Warning: regex failed to decode '$version' for $name found in $($funcFile.FullName)"    
+                        Write-Host "Warning: regex failed to decode '$version' for $name found in $($funcFile.FullName)"
                     }
                 }
             }
-            else 
+            else
             {
                 $serverVersion = Remove-Prefix $serverVersion
 
@@ -163,22 +163,22 @@ try
                     {
                         $versionName = "Server" + $match.Groups[2].Value
                     }
-        
+
                     if ($versionMap.ContainsKey($versionName))
                     {
                         $fixedVersion = $versionMap[$versionName]
                     }
-                    else 
+                    else
                     {
                         Write-Error "Failed to lookup windows server version: $serverVersion"
                     }
                 }
                 else
                 {
-                    Write-Output "Warning: regex failed to decode server '$serverVersion' for $name found in $($funcFile.FullName)"    
+                    Write-Host "Warning: regex failed to decode server '$serverVersion' for $name found in $($funcFile.FullName)"
                 }
             }
-    
+
             if (![string]::IsNullOrEmpty($fixedVersion))
             {
                 if ($writtenItems.ContainsKey($name))
@@ -186,7 +186,7 @@ try
                     $oldValue = $writtenItems[$name]
                     if ($oldValue -ne $fixedVersion)
                     {
-                        Write-Output "Duplicate, differing versions for $name - $oldValue vs. $fixedVersion"
+                        Write-Host "Duplicate, differing versions for $name - $oldValue vs. $fixedVersion"
                     }
                 }
                 else
@@ -198,7 +198,7 @@ try
         }
     }
 }
-finally 
+finally
 {
     $stream.Close()
 }

--- a/scripts/CreateUsingsForGeneratedSources.ps1
+++ b/scripts/CreateUsingsForGeneratedSources.ps1
@@ -7,7 +7,7 @@ param
 
 if (!(Test-Path -path $techRootToNamespaceMappingsFileName))
 {
-    Write-Output "Error: Couldn't find csv file $techRootToNamespaceMappingsFileName."
+    Write-Error "Couldn't find csv file $techRootToNamespaceMappingsFileName."
     exit -1
 }
 

--- a/scripts/DisplayPossibleMappings.ps1
+++ b/scripts/DisplayPossibleMappings.ps1
@@ -34,7 +34,7 @@ foreach ($match in $remapMatches)
         continue
     }
 
-    $stream.WriteLine($match.Groups[1].Value)    
+    $stream.WriteLine($match.Groups[1].Value)
     $count++
 }
 
@@ -42,5 +42,5 @@ $stream.Close()
 
 if ($count -ne 0)
 {
-    Write-Output "$count remaps emitted at: $remapsFile"
+    Write-Host "$count remaps emitted at: $remapsFile"
 }

--- a/scripts/DoPackages.ps1
+++ b/scripts/DoPackages.ps1
@@ -10,7 +10,7 @@ if (!$skipInstallTools)
     Install-BuildTools
 }
 
-Write-Output "`e[36m*** Packing packages...`e[0m"
+Write-Host "*** Packing packages..." -ForegroundColor Blue
 
 dotnet pack "$PSScriptRoot\..\sources\packages.proj" -c Release
 ThrowOnNativeProcessError

--- a/scripts/DoSamples.ps1
+++ b/scripts/DoSamples.ps1
@@ -16,17 +16,17 @@ Write-Host "*** Building samples..." -ForegroundColor Blue
 
 $cppSampleProj = "$rootDir\sources\GeneratorSdk\samples\CppProjectForScraping\CppProjectForScraping.vcxproj"
 
-msbuild $cppSampleProj /p:Configuration=Release /p:Platform=Win32 /t:rebuild
+msbuild $cppSampleProj /p:Configuration=Release /p:Platform=Win32 /t:rebuild "-bl:$PSScriptRoot\..\bin\logs\samples_cppSample_win32.binlog"
 ThrowOnNativeProcessError
 
-msbuild $cppSampleProj /p:Configuration=Release /p:Platform=x64 /t:rebuild
+msbuild $cppSampleProj /p:Configuration=Release /p:Platform=x64 /t:rebuild "-bl:$PSScriptRoot\..\bin\logs\samples_cppSample_x64.binlog"
 ThrowOnNativeProcessError
 
-msbuild $cppSampleProj /p:Configuration=Release /p:Platform=ARM64 /t:rebuild
+msbuild $cppSampleProj /p:Configuration=Release /p:Platform=ARM64 /t:rebuild "-bl:$PSScriptRoot\..\bin\logs\samples_cppSample_arm64.binlog"
 ThrowOnNativeProcessError
 
 dotnet clean "$PSScriptRoot\..\sources\GeneratorSdk\samples"
 ThrowOnNativeProcessError
 
-dotnet build "$PSScriptRoot\..\sources\GeneratorSdk\samples" -c Release
+dotnet build "$PSScriptRoot\..\sources\GeneratorSdk\samples" -c Release "-bl:$PSScriptRoot\..\bin\logs\samples.binlog"
 ThrowOnNativeProcessError

--- a/scripts/DoSamples.ps1
+++ b/scripts/DoSamples.ps1
@@ -10,7 +10,7 @@ if (!$skipInstallTools)
     Install-BuildTools
 }
 
-Write-Output "`e[36m*** Building samples...`e[0m"
+Write-Host "*** Building samples..." -ForegroundColor Blue
 
 & "$PSScriptRoot\UpdateGlobalJsonWinmdGeneratorVersion.ps1"
 

--- a/scripts/DoTests.ps1
+++ b/scripts/DoTests.ps1
@@ -10,10 +10,9 @@ if (!$skipInstallTools)
     Install-BuildTools
 }
 
-Write-Output "`e[36m*** Running metadata utils tests...`e[0m"
+Write-Host "*** Running metadata utils tests..." -ForegroundColor Blue
 
 dotnet test "$PSScriptRoot\..\tests\MetadataUtils.Tests" -c Release
 ThrowOnNativeProcessError
 
 & $PSScriptRoot\TestWinmdBinary.ps1 -SkipInstallTools
-

--- a/scripts/GenerateMetadataSource.ps1
+++ b/scripts/GenerateMetadataSource.ps1
@@ -10,7 +10,7 @@ param
 
 . "$PSScriptRoot\CommonUtils.ps1"
 
-Write-Output "`e[36m*** Generating source files: $arch`e[0m"
+Write-Host "*** Generating source files: $arch" -ForegroundColor Blue
 
 Install-BuildTools
 

--- a/scripts/GenerateMetadataSource.ps1
+++ b/scripts/GenerateMetadataSource.ps1
@@ -23,5 +23,5 @@ else
     $target = "ScrapeHeaders"
 }
 
-dotnet build "$windowsWin32ProjectRoot" -c Release -p:ScanArch=$arch -t:$target
+dotnet build "$windowsWin32ProjectRoot" -c Release -p:ScanArch=$arch -t:$target "-bl:$PSScriptRoot\..\bin\logs\GenerateMetadataSources.binlog"
 ThrowOnNativeProcessError

--- a/scripts/Install-AllSoftware.ps1
+++ b/scripts/Install-AllSoftware.ps1
@@ -1,18 +1,18 @@
 # 1. Make sure the Microsoft App Installer is installed:
 #    https://www.microsoft.com/p/app-installer/9nblggh4nns1
-# 2. Run this script as administrator. If running scripts is blocked, you can temporarily unblock them by running 
+# 2. Run this script as administrator. If running scripts is blocked, you can temporarily unblock them by running
 #    Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Scope Process
 
 function Check-IsElevated
  {
     $id = [System.Security.Principal.WindowsIdentity]::GetCurrent()
     $p = New-Object System.Security.Principal.WindowsPrincipal($id)
-    if ($p.IsInRole([System.Security.Principal.WindowsBuiltInRole]::Administrator)) { 
-        Write-Output $true 
-    }      
-    else { 
-        Write-Output $false 
-    }   
+    if ($p.IsInRole([System.Security.Principal.WindowsBuiltInRole]::Administrator)) {
+        return $true
+    }
+    else {
+        return $false
+    }
  }
 
 $policy = Get-ExecutionPolicy
@@ -24,7 +24,7 @@ elseif (-not(Check-IsElevated)){
     throw "Please run this script as an administrator"
 }
 else {
-    Write-Output "Installing apps"
+    Write-Host "Installing apps"
     $apps = @(
     @{packageID = "icsharpcode.ILSpy" },
     @{packageID = "Microsoft.DotNet.SDK.6" },
@@ -33,12 +33,12 @@ else {
     Foreach ($app in $apps) {
         $listApp = winget list --exact -q $app.packageIDs
         if (![String]::Join("", $listApp).Contains($app.packageID)) {
-            Write-Output "Installing: $($app.packageID)"
-            winget install -h $app.packageID -s winget 
+            Write-Host "Installing: $($app.packageID)"
+            winget install -h $app.packageID -s winget
         }
         else {
-            Write-Output "Skipping: $($app.packageID) (already installed)"
+            Write-Host "Skipping: $($app.packageID) (already installed)"
         }
     }
-    & "$PSScriptRoot\Get-VSPath.ps1" | Out-Null 
+    & "$PSScriptRoot\Get-VSPath.ps1" | Out-Null
 }

--- a/scripts/RecompileIdlFilesForScraping.ps1
+++ b/scripts/RecompileIdlFilesForScraping.ps1
@@ -12,17 +12,17 @@ $sdkIncludeDir = (Get-ChildItem -Path "$cppPkgPath\c\include").FullName
 
 if (!(Test-Path -path $sdkIncludeDir))
 {
-    Write-Output "Error: Couldn't find $sdkIncludeDir."
+    Write-Error "Couldn't find $sdkIncludeDir."
     exit -1
 }
 
-Write-Output "Copying headers from Win SDK...$sdkIncludeDir to $recompiledIdlHeadersDir"
+Write-Host "Copying headers from Win SDK...$sdkIncludeDir to $recompiledIdlHeadersDir"
 copy-item -Path "$sdkIncludeDir\um" -destination "$recompiledIdlHeadersDir" -recurse
 copy-item -Path "$sdkIncludeDir\shared" -destination "$recompiledIdlHeadersDir" -recurse
 copy-item -Path "$sdkIncludeDir\winrt" -destination "$recompiledIdlHeadersDir" -recurse
 copy-item -Path "$sdkIncludeDir\ucrt" -destination "$recompiledIdlHeadersDir" -recurse
 
-Write-Output "Recompiling midl headers with SAL annotations in $recompiledIdlHeadersDir"
+Write-Host "Recompiling midl headers with SAL annotations in $recompiledIdlHeadersDir"
 
 $version = [System.IO.Path]::GetFileName($cppPkgPath)
 $sdkParts = $version.Split('.')
@@ -32,7 +32,7 @@ $sdkBinDir = "$cppPkgPath\c\bin\$sdkVersion\x86"
 
 if (!(Test-Path -path $sdkBinDir))
 {
-    Write-Output "Error: Couldn't find $sdkBinDir."
+    Write-Error "Couldn't find $sdkBinDir."
     exit -1
 }
 
@@ -61,11 +61,11 @@ if ($throttleCount -lt 2)
     $throttleCount = 2
 }
 
-Write-Output "Updating annotations in idl files..."
+Write-Host "Updating annotations in idl files..."
 
 $idlFiles = Get-ChildItem "$sdkIncludeDir\um\*.idl","$sdkIncludeDir\shared\*.idl"
 $foundIdlFiles = [System.Collections.ArrayList]@()
-foreach ($idlFile in $idlFiles)    
+foreach ($idlFile in $idlFiles)
 {
     if ($idlFile.BaseName -in $excludedHeaders)
     {
@@ -98,7 +98,7 @@ foreach ($idlFile in $idlFiles)
 $ErrorActionPreference = "Continue"
 $foundIdlFiles | ForEach-Object -Parallel {
     $idlFile = $_
- 
+
     $origHeader = [io.path]::ChangeExtension($idlFile.FullName, "h")
 
     $fixedIdlFile =  "$using:scratchDir\$($idlFile.Name)"
@@ -113,9 +113,9 @@ $foundIdlFiles | ForEach-Object -Parallel {
         $outText += Get-Content -Path $outputLog -Raw
         Write-Error $outText
     }
-    else 
+    else
     {
-        Write-Output "Compiled $($idlFile.Name)"
+        Write-Host "Compiled $($idlFile.Name)"
 
         # This line gets pulled out in the Windows build of the header. We need to do the same or it won't compile
         if ($idlFile.BaseName -eq "d3d10_1")

--- a/scripts/TestHeaderFileCoverage.ps1
+++ b/scripts/TestHeaderFileCoverage.ps1
@@ -38,7 +38,7 @@ function GetUnconveredFilesMap()
 $traverseFiles = GetTraverseHash
 $uncoveredFilesMap = GetUnconveredFilesMap
 
-Write-Output "Scanning header files..."
+Write-Host "Scanning header files..."
 
 $sdkIncludePath = $recompiledIdlHeadersDir
 $headerFiles = Get-ChildItem -Recurse -Filter *.h "$sdkIncludePath/shared", "$sdkIncludePath/um"
@@ -57,12 +57,12 @@ foreach ($file in $headerFiles)
         $reason = $uncoveredFilesMap[$nameToCheck]
         if ($reason -eq "skipping")
         {
-            $traversed++    
+            $traversed++
 
             continue
         }
 
-        #Write-Output "reason = $reason"
+        #Write-Host "reason = $reason"
 
         if (!$reason)
         {
@@ -73,19 +73,19 @@ foreach ($file in $headerFiles)
     }
     else
     {
-        $traversed++    
+        $traversed++
     }
 }
 
 if ($finalList.Count -gt 0)
 {
-    Write-Output "The below header files are not included in any partition:"
+    Write-Host "The below header files are not included in any partition:"
     foreach ($item in $finalList.Keys)
     {
         $reason = $finalList[$item]
-        Write-Output "$item - $reason"
+        Write-Host "$item - $reason"
     }
 }
 
 $percent = ($traversed/$total).ToString("P")
-Write-Output "$traversed/$total covered by partitions or exceptions ($percent)"
+Write-Host "$traversed/$total covered by partitions or exceptions ($percent)"

--- a/scripts/TestWinmdBinary.ps1
+++ b/scripts/TestWinmdBinary.ps1
@@ -11,15 +11,15 @@ if (!$SkipInstallTools.IsPresent)
     Install-BuildTools
 }
 
-Write-Output "`e[36m*** Running tests on .winmd`e[0m"
+Write-Host "*** Running tests on .winmd" -ForegroundColor Blue
 
 $windowsWin32TestsDir = "$rootDir\tests\Windows.Win32.Tests"
 dotnet test $windowsWin32TestsDir -c:Release
 ThrowOnNativeProcessError
 
-Write-Output "`n`e[32mTesting .winmd succeeded`e[0m"
+Write-Host "`n`e[32mTesting .winmd succeeded`e[0m"
 
-Write-Output "`e[36m*** Comparing .winmd to last release`e[0m"
+Write-Host "*** Comparing .winmd to last release" -ForegroundColor Blue
 
 & "$PSScriptRoot\CompareBinToLastRelease.ps1" -SkipInstallTools
 
@@ -28,6 +28,6 @@ if ($LastExitCode -lt 0)
     exit -1
 }
 
-Write-Output "`n`e[32mComparing .winmd to last release succeeded`e[0m"
+Write-Host "`n`e[32mComparing .winmd to last release succeeded`e[0m"
 
 exit 0

--- a/sources/ConstantsScraper/Program.cs
+++ b/sources/ConstantsScraper/Program.cs
@@ -62,13 +62,13 @@ namespace ConstantsScraperApp
             ScraperResults results;
             try
             {
-                results = 
+                results =
                     ConstantsScraper.ScrapeConstants(
                         enumJsonFiles, defaultNamespace, scraperOutputDir, headerText, exclusionNames, traversedHeadersToNamespaces, requiredNamespaces, remaps, withTypes, withAttributes);
             }
             catch (System.Exception e)
             {
-                context.Console.Out.Write($"Failed to scrape constants:\r\n{e.Message}\r\n{e.StackTrace}");
+                context.Console.Error.Write($"Failed to scrape constants:\r\n{e.Message}\r\n{e.StackTrace}");
                 return -1;
             }
 

--- a/sources/GeneratorSdk/sdk/sdk.targets
+++ b/sources/GeneratorSdk/sdk/sdk.targets
@@ -10,7 +10,7 @@
   <UsingTask TaskName="MetadataTasks.MergeFilesIntoFile" AssemblyFile="$(TaskBinDir)\MetadataTasks.dll"/>
   <UsingTask TaskName="MetadataTasks.PrepSettingsForFunctionPointerFixups" AssemblyFile="$(TaskBinDir)\MetadataTasks.dll"/>
   <UsingTask TaskName="MetadataTasks.PrepSettingsForAutoTypes" AssemblyFile="$(TaskBinDir)\MetadataTasks.dll"/>
-  
+
   <UsingTask TaskName="GetFirstPartitionNamespace" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v12.0.dll">
     <ParameterGroup>
       <Items ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true" />
@@ -246,7 +246,9 @@
       HeaderTextFile="$(FinalConstantsScraperHeaderFile)"
       MarkerFileName="$(ScrapedConstantsMarker)"
       SdkIncRoot="$(SdkIncRoot)"
-      MSBuildProjectDirectory="$(MSBuildProjectDirectory)"/>
+      MSBuildProjectDirectory="$(MSBuildProjectDirectory)"
+      StandardErrorImportance="high"
+      />
 
   </Target>
 


### PR DESCRIPTION
I needed some of these changes to diagnose the enum parsing failures from #1228. Since they are overall goodness, I wanted to share.

-  Capture msbuild binlogs in local builds and in the pipeline
- Emit constants scraper errors in the console log
  Errors should be written to STDERR, and msbuild should invoke tools such that STDERR gets treated with high priority.
- Use powershell `Write-Host` and `Write-Error` as appropriate
    This avoids needing to use terminal escape codes to colorize output.
    This directs errors to the STDERR stream as appropriate.