### PR TITLE
MsHtml/OLE enum changes

### DIFF
--- a/generation/WinSDK/enums.json
+++ b/generation/WinSDK/enums.json
@@ -8234,9 +8234,80 @@
     ]
   },
   {
-    "addUsesTo": "DVASPECT",
-    "members": [],
+    "name": "DVASPECT",
+    "type": "uint",
+    "members": [
+      {
+        "name": "DVASPECT_CONTENT",
+        "value": "1"
+      },
+      {
+        "name": "DVASPECT_THUMBNAIL",
+        "value": "2"
+      },
+      {
+        "name": "DVASPECT_ICON",
+        "value": "4"
+      },
+      {
+        "name": "DVASPECT_DOCPRINT",
+        "value": "8"
+      },
+      {
+        "name": "DVASPECT_OPAQUE",
+        "value": "16"
+      },
+      {
+        "name": "DVASPECT_TRANSPARENT",
+        "value": "32"
+      }
+    ],
     "uses": [
+      {
+        "interface": "IOleObject",
+        "method": "GetExtent",
+        "parameter": "dwDrawAspect"
+      },
+      {
+        "interface": "IOleObject",
+        "method": "SetExtent",
+        "parameter": "dwDrawAspect"
+      },
+      {
+        "interface": "IOleObject",
+        "method": "GetMiscStatus",
+        "parameter": "dwAspect"
+      },
+      {
+        "interface": "IViewObject",
+        "method": "Draw",
+        "parameter": "dwDrawAspect"
+      },
+      {
+        "interface": "IViewObject",
+        "method": "SetAdvise",
+        "parameter": "aspects"
+      },
+      {
+        "interface": "IViewObject",
+        "method": "GetAdvise",
+        "parameter": "aspects"
+      },
+      {
+        "interface": "IViewObject",
+        "method": "GetColorSet",
+        "parameter": "dwDrawAspect"
+      },
+      {
+        "interface": "IViewObject",
+        "method": "Freeze",
+        "parameter": "dwDrawAspect"
+      },
+      {
+        "interface": "IViewObject2",
+        "method": "GetExtent",
+        "parameter": "dwDrawAspect"
+      },
       {
         "interface": "ITextServices",
         "method": "TxQueryHitPoint",
@@ -8251,6 +8322,15 @@
         "interface": "ITextServices",
         "method": "OnTxSetCursor",
         "parameter": "dwDrawAspect"
+      },
+      {
+        "interface": "IViewObjectEx",
+        "method": "GetNaturalExtent",
+        "parameter": "dwAspect"
+      },
+      {
+        "struct": "REPASTESPECIAL",
+        "field": "dwAspect"
       }
     ]
   },
@@ -16948,17 +17028,6 @@
     ]
   },
   {
-    "addUsesTo": "DVASPECT",
-    "members": [],
-    "uses": [
-      {
-        "interface": "IViewObjectEx",
-        "method": "GetNaturalExtent",
-        "parameter": "dwAspect"
-      }
-    ]
-  },
-  {
     "name": "IME_PAD_REQUEST_FLAGS",
     "members": [
       {
@@ -20959,16 +21028,6 @@
       {
         "struct": "EV_EXTRA_CERT_CHAIN_POLICY_PARA",
         "field": "dwRootProgramQualifierFlags"
-      }
-    ]
-  },
-  {
-    "addUsesTo": "DVASPECT",
-    "members": [],
-    "uses": [
-      {
-        "struct": "REPASTESPECIAL",
-        "field": "dwAspect"
       }
     ]
   },
@@ -30851,20 +30910,6 @@
     ]
   },
   {
-    "name": "CTRLINFO_FLAGS",
-    "autoPopulate": {
-      "filter": "CTRLINFO_EATS_",
-      "header": "ocidl.h"
-    },
-    "members": [],
-    "uses": [
-      {
-        "struct": "CONTROLINFO",
-        "field": "dwFlags"
-      }
-    ]
-  },
-  {
     "addUsesTo": "INVOKEKIND",
     "uses": [
       {
@@ -32220,7 +32265,7 @@
     "uses": [
       {
         "struct": "CONTROLINFO",
-        "parameter": "dwFlags"
+        "field": "dwFlags"
       }
     ]
   },
@@ -34590,6 +34635,43 @@
       },
       {
         "name": "SB_ENDSCROLL"
+      }
+    ]
+  },
+  {
+    "addUsesTo": "DOCHOSTUIFLAG",
+    "uses": [
+      {
+        "struct": "DOCHOSTUIINFO",
+        "field": "dwFlags"
+      }
+    ]
+  },
+  {
+    "addUsesTo": "DOCHOSTUIDBLCLK",
+    "uses": [
+      {
+        "struct": "DOCHOSTUIINFO",
+        "field": "dwDoubleClick"
+      }
+    ]
+  },
+  {
+    "addUsesTo": "FUNCFLAGS",
+    "uses": [
+      {
+        "struct": "FUNCDESC",
+        "field": "wFuncFlags"
+      }
+    ]
+  },
+  {
+    "addUsesTo": "ADVF",
+    "uses": [
+      {
+        "interface": "IViewObject",
+        "method": "SetAdvise",
+        "parameter": "advf"
       }
     ]
   }

--- a/generation/WinSDK/requiredNamespacesForNames.rsp
+++ b/generation/WinSDK/requiredNamespacesForNames.rsp
@@ -306,6 +306,7 @@ ITypeInfo2=Windows.Win32.System.Com
 TYPEATTR=Windows.Win32.System.Com
 TYPEKIND=Windows.Win32.System.Com
 FUNCDESC=Windows.Win32.System.Com
+FUNCFLAGS=Windows.Win32.System.Com
 ELEMDESC=Windows.Win32.System.Com
 TYPEDESC=Windows.Win32.System.Com
 INVOKEKIND=Windows.Win32.System.Com

--- a/generation/WinSDK/scraper.settings.rsp
+++ b/generation/WinSDK/scraper.settings.rsp
@@ -98,6 +98,8 @@ IDirectDraw7Vtbl
 IDirectDrawKernelVtbl
 IDirectDrawSurfaceKernelVtbl
 IDirectDrawGammaControlVtbl
+tagDVASPECT2
+tagDVASPECT
 --remap
 ABI::Windows::Foundation::IActivatableClassRegistration=IActivatableClassRegistration
 adpcmcoef_tag=ADPCMCOEFSET
@@ -302,8 +304,6 @@ tagDOMNodeType=DOMNodeType
 tagDRAWITEMSTRUCT=DRAWITEMSTRUCT
 tagDRAWTEXTPARAMS=DRAWTEXTPARAMS
 tagDROPSTRUCT=DROPSTRUCT
-tagDVASPECT2=DVASPECT2
-tagDVASPECT=DVASPECT
 tagDVTARGETDEVICE=DVTARGETDEVICE
 tagELEMDESC=ELEMDESC
 tagEMR=EMR

--- a/scripts/ChangesSinceLastRelease.txt
+++ b/scripts/ChangesSinceLastRelease.txt
@@ -1714,3 +1714,51 @@ Windows.Win32.UI.Controls.HIT_TEST_BACKGROUND_OPTIONS.HTTB_SYSTEMSIZINGMARGINS a
 Windows.Win32.System.Threading.Apis.WaitOnAddress : [DllImport(vertdll.dll,ExactSpelling=True,PreserveSig=False,SetLastError=True),SupportedOSPlatform(windows8.0)] => [DllImport(api-ms-win-core-synch-l1-2-0.dll,ExactSpelling=True,PreserveSig=False,SetLastError=True),SupportedOSPlatform(windows8.0)]
 Windows.Win32.System.Threading.Apis.WakeByAddressAll : [DllImport(vertdll.dll,ExactSpelling=True,PreserveSig=False),SupportedOSPlatform(windows8.0)] => [DllImport(api-ms-win-core-synch-l1-2-0.dll,ExactSpelling=True,PreserveSig=False),SupportedOSPlatform(windows8.0)]
 Windows.Win32.System.Threading.Apis.WakeByAddressSingle : [DllImport(vertdll.dll,ExactSpelling=True,PreserveSig=False),SupportedOSPlatform(windows8.0)] => [DllImport(api-ms-win-core-synch-l1-2-0.dll,ExactSpelling=True,PreserveSig=False),SupportedOSPlatform(windows8.0)]
+# winforms enum changes
+Windows.Win32.System.Com.DVASPECT.DVASPECT_OPAQUE added
+Windows.Win32.System.Com.DVASPECT.DVASPECT_TRANSPARENT added
+Windows.Win32.System.Com.DVASPECT.value__...System.Int32 => System.UInt32
+Windows.Win32.System.Com.FUNCDESC.wFuncFlags...System.UInt16 => Windows.Win32.System.Com.FUNCFLAGS
+Windows.Win32.System.Com.FUNCFLAGS added
+Windows.Win32.System.Com.FUNCFLAGS.FUNCFLAG_FBINDABLE added
+Windows.Win32.System.Com.FUNCFLAGS.FUNCFLAG_FDEFAULTBIND added
+Windows.Win32.System.Com.FUNCFLAGS.FUNCFLAG_FDEFAULTCOLLELEM added
+Windows.Win32.System.Com.FUNCFLAGS.FUNCFLAG_FDISPLAYBIND added
+Windows.Win32.System.Com.FUNCFLAGS.FUNCFLAG_FHIDDEN added
+Windows.Win32.System.Com.FUNCFLAGS.FUNCFLAG_FIMMEDIATEBIND added
+Windows.Win32.System.Com.FUNCFLAGS.FUNCFLAG_FNONBROWSABLE added
+Windows.Win32.System.Com.FUNCFLAGS.FUNCFLAG_FREPLACEABLE added
+Windows.Win32.System.Com.FUNCFLAGS.FUNCFLAG_FREQUESTEDIT added
+Windows.Win32.System.Com.FUNCFLAGS.FUNCFLAG_FRESTRICTED added
+Windows.Win32.System.Com.FUNCFLAGS.FUNCFLAG_FSOURCE added
+Windows.Win32.System.Com.FUNCFLAGS.FUNCFLAG_FUIDEFAULT added
+Windows.Win32.System.Com.FUNCFLAGS.FUNCFLAG_FUSESGETLASTERROR added
+Windows.Win32.System.Ole.CONTROLINFO.dwFlags...System.UInt32 => Windows.Win32.System.Ole.CTRLINFO
+Windows.Win32.System.Ole.DVASPECT2 removed
+Windows.Win32.System.Ole.DVASPECT2.DVASPECT_OPAQUE removed
+Windows.Win32.System.Ole.DVASPECT2.DVASPECT_TRANSPARENT removed
+Windows.Win32.System.Ole.FUNCFLAGS removed
+Windows.Win32.System.Ole.FUNCFLAGS.FUNCFLAG_FBINDABLE removed
+Windows.Win32.System.Ole.FUNCFLAGS.FUNCFLAG_FDEFAULTBIND removed
+Windows.Win32.System.Ole.FUNCFLAGS.FUNCFLAG_FDEFAULTCOLLELEM removed
+Windows.Win32.System.Ole.FUNCFLAGS.FUNCFLAG_FDISPLAYBIND removed
+Windows.Win32.System.Ole.FUNCFLAGS.FUNCFLAG_FHIDDEN removed
+Windows.Win32.System.Ole.FUNCFLAGS.FUNCFLAG_FIMMEDIATEBIND removed
+Windows.Win32.System.Ole.FUNCFLAGS.FUNCFLAG_FNONBROWSABLE removed
+Windows.Win32.System.Ole.FUNCFLAGS.FUNCFLAG_FREPLACEABLE removed
+Windows.Win32.System.Ole.FUNCFLAGS.FUNCFLAG_FREQUESTEDIT removed
+Windows.Win32.System.Ole.FUNCFLAGS.FUNCFLAG_FRESTRICTED removed
+Windows.Win32.System.Ole.FUNCFLAGS.FUNCFLAG_FSOURCE removed
+Windows.Win32.System.Ole.FUNCFLAGS.FUNCFLAG_FUIDEFAULT removed
+Windows.Win32.System.Ole.FUNCFLAGS.FUNCFLAG_FUSESGETLASTERROR removed
+Windows.Win32.System.Ole.IOleObject.GetExtent : dwDrawAspect...UInt32 => DVASPECT
+Windows.Win32.System.Ole.IOleObject.GetMiscStatus : dwAspect...UInt32 => DVASPECT
+Windows.Win32.System.Ole.IOleObject.SetExtent : dwDrawAspect...UInt32 => DVASPECT
+Windows.Win32.System.Ole.IViewObject.Draw : dwDrawAspect...UInt32 => DVASPECT
+Windows.Win32.System.Ole.IViewObject.Freeze : dwDrawAspect...UInt32 => DVASPECT
+Windows.Win32.System.Ole.IViewObject.GetColorSet : dwDrawAspect...UInt32 => DVASPECT
+Windows.Win32.System.Ole.IViewObject.SetAdvise : advf...UInt32 => ADVF
+Windows.Win32.System.Ole.IViewObject.SetAdvise : aspects...UInt32 => DVASPECT
+Windows.Win32.System.Ole.IViewObject2.GetExtent : dwDrawAspect...UInt32 => DVASPECT
+Windows.Win32.Web.MsHtml.DOCHOSTUIINFO.dwDoubleClick...System.UInt32 => Windows.Win32.Web.MsHtml.DOCHOSTUIDBLCLK
+Windows.Win32.Web.MsHtml.DOCHOSTUIINFO.dwFlags...System.UInt32 => Windows.Win32.Web.MsHtml.DOCHOSTUIFLAG


### PR DESCRIPTION
Fixes #1129
Also fixed FUNCFLAGS and MsHtml.DOCHOSTUIINFO enums
Winforms Tracking: https://github.com/dotnet/winforms/issues/7468
```
Windows.Win32.System.Com.DVASPECT.DVASPECT_OPAQUE added
Windows.Win32.System.Com.DVASPECT.DVASPECT_TRANSPARENT added
Windows.Win32.System.Com.DVASPECT.value__...System.Int32 => System.UInt32
Windows.Win32.System.Com.FUNCDESC.wFuncFlags...System.UInt16 => Windows.Win32.System.Com.FUNCFLAGS
Windows.Win32.System.Com.FUNCFLAGS added
Windows.Win32.System.Com.FUNCFLAGS.FUNCFLAG_FBINDABLE added
Windows.Win32.System.Com.FUNCFLAGS.FUNCFLAG_FDEFAULTBIND added
Windows.Win32.System.Com.FUNCFLAGS.FUNCFLAG_FDEFAULTCOLLELEM added
Windows.Win32.System.Com.FUNCFLAGS.FUNCFLAG_FDISPLAYBIND added
Windows.Win32.System.Com.FUNCFLAGS.FUNCFLAG_FHIDDEN added
Windows.Win32.System.Com.FUNCFLAGS.FUNCFLAG_FIMMEDIATEBIND added
Windows.Win32.System.Com.FUNCFLAGS.FUNCFLAG_FNONBROWSABLE added
Windows.Win32.System.Com.FUNCFLAGS.FUNCFLAG_FREPLACEABLE added
Windows.Win32.System.Com.FUNCFLAGS.FUNCFLAG_FREQUESTEDIT added
Windows.Win32.System.Com.FUNCFLAGS.FUNCFLAG_FRESTRICTED added
Windows.Win32.System.Com.FUNCFLAGS.FUNCFLAG_FSOURCE added
Windows.Win32.System.Com.FUNCFLAGS.FUNCFLAG_FUIDEFAULT added
Windows.Win32.System.Com.FUNCFLAGS.FUNCFLAG_FUSESGETLASTERROR added
Windows.Win32.System.Ole.CONTROLINFO.dwFlags...System.UInt32 => Windows.Win32.System.Ole.CTRLINFO
Windows.Win32.System.Ole.DVASPECT2 removed
Windows.Win32.System.Ole.DVASPECT2.DVASPECT_OPAQUE removed
Windows.Win32.System.Ole.DVASPECT2.DVASPECT_TRANSPARENT removed
Windows.Win32.System.Ole.FUNCFLAGS removed
Windows.Win32.System.Ole.FUNCFLAGS.FUNCFLAG_FBINDABLE removed
Windows.Win32.System.Ole.FUNCFLAGS.FUNCFLAG_FDEFAULTBIND removed
Windows.Win32.System.Ole.FUNCFLAGS.FUNCFLAG_FDEFAULTCOLLELEM removed
Windows.Win32.System.Ole.FUNCFLAGS.FUNCFLAG_FDISPLAYBIND removed
Windows.Win32.System.Ole.FUNCFLAGS.FUNCFLAG_FHIDDEN removed
Windows.Win32.System.Ole.FUNCFLAGS.FUNCFLAG_FIMMEDIATEBIND removed
Windows.Win32.System.Ole.FUNCFLAGS.FUNCFLAG_FNONBROWSABLE removed
Windows.Win32.System.Ole.FUNCFLAGS.FUNCFLAG_FREPLACEABLE removed
Windows.Win32.System.Ole.FUNCFLAGS.FUNCFLAG_FREQUESTEDIT removed
Windows.Win32.System.Ole.FUNCFLAGS.FUNCFLAG_FRESTRICTED removed
Windows.Win32.System.Ole.FUNCFLAGS.FUNCFLAG_FSOURCE removed
Windows.Win32.System.Ole.FUNCFLAGS.FUNCFLAG_FUIDEFAULT removed
Windows.Win32.System.Ole.FUNCFLAGS.FUNCFLAG_FUSESGETLASTERROR removed
Windows.Win32.System.Ole.IOleObject.GetExtent : dwDrawAspect...UInt32 => DVASPECT
Windows.Win32.System.Ole.IOleObject.GetMiscStatus : dwAspect...UInt32 => DVASPECT
Windows.Win32.System.Ole.IOleObject.SetExtent : dwDrawAspect...UInt32 => DVASPECT
Windows.Win32.System.Ole.IViewObject.Draw : dwDrawAspect...UInt32 => DVASPECT
Windows.Win32.System.Ole.IViewObject.Freeze : dwDrawAspect...UInt32 => DVASPECT
Windows.Win32.System.Ole.IViewObject.GetColorSet : dwDrawAspect...UInt32 => DVASPECT
Windows.Win32.System.Ole.IViewObject.SetAdvise : advf...UInt32 => ADVF
Windows.Win32.System.Ole.IViewObject.SetAdvise : aspects...UInt32 => DVASPECT
Windows.Win32.System.Ole.IViewObject2.GetExtent : dwDrawAspect...UInt32 => DVASPECT
Windows.Win32.Web.MsHtml.DOCHOSTUIINFO.dwDoubleClick...System.UInt32 => Windows.Win32.Web.MsHtml.DOCHOSTUIDBLCLK
Windows.Win32.Web.MsHtml.DOCHOSTUIINFO.dwFlags...System.UInt32 => Windows.Win32.Web.MsHtml.DOCHOSTUIFLAG
```