### PR TITLE
Add ComOutPtr to SHGetPropertyStoreFromParsingName

### DIFF
--- a/generation/WinSDK/emitter.settings.rsp
+++ b/generation/WinSDK/emitter.settings.rsp
@@ -1173,3 +1173,4 @@ OleTranslateColor::lpcolorref=[Out]
 DWriteCreateFactory::factory=[ComOutPtr]void**
 TrackPopupMenu::prcRect=[In][Optional][-Reserved]
 LdapMapErrorToWin32::return=WIN32_ERROR
+SHGetPropertyStoreFromParsingName::ppv=[ComOutPtr]

--- a/scripts/ChangesSinceLastRelease.txt
+++ b/scripts/ChangesSinceLastRelease.txt
@@ -162,3 +162,5 @@ Windows.Win32.UI.Controls.Apis.OpenThemeData : return...IntPtr => HTHEME
 Windows.Win32.UI.Controls.Apis.OpenThemeDataEx : return...IntPtr => HTHEME
 Windows.Win32.UI.Controls.HTHEME added
 Windows.Win32.UI.HiDpi.Apis.OpenThemeDataForDpi : return...IntPtr => HTHEME
+# SHGetPropertyStoreFromParsingName
+Windows.Win32.UI.Shell.PropertiesSystem.Apis.SHGetPropertyStoreFromParsingName : ppv : [Out] => [ComOutPtr,Out]


### PR DESCRIPTION
Fixes: #1279 

Metadata diff:
```
Windows.Win32.UI.Shell.PropertiesSystem.Apis.SHGetPropertyStoreFromParsingName : ppv : [Out] => [ComOutPtr,Out]
```