### PR TITLE
Add in SHGSI Enum

### DIFF
--- a/generation/WinSDK/enums.json
+++ b/generation/WinSDK/enums.json
@@ -34718,6 +34718,50 @@
         "parameter": "LdapError"
       }
     ]
+  },
+  {
+    "type": "uint",
+    "name": "SHGSI_FLAGS",
+    "flags": true,
+    "members": [
+      {
+        "name": "SHGSI_ICONLOCATION"
+      },
+      {
+        "name": "SHGSI_ICON",
+        "value": "0x000000100"
+      },
+      {
+        "name": "SHGSI_SYSICONINDEX",
+        "value": "0x000004000"
+      },
+      {
+        "name": "SHGSI_LINKOVERLAY",
+        "value": "0x000008000"
+      },
+      {
+        "name": "SHGSI_SELECTED",
+        "value": "0x000010000"
+      },
+      {
+        "name": "SHGSI_LARGEICON",
+        "value": "0x000000000"
+      },
+      {
+        "name": "SHGSI_SMALLICON",
+        "value": "0x000000001"
+      },
+      {
+        "name": "SHGSI_SHELLICONSIZE",
+        "value": "0x000000004"
+      }
+    ],
+    "uses": [
+      {
+        "method": "SHGetStockIconInfo",
+        "parameter": "uFlags"
+      }
+    ]
   }
 ]
 }

--- a/scripts/ChangesSinceLastRelease.txt
+++ b/scripts/ChangesSinceLastRelease.txt
@@ -143,3 +143,15 @@ Windows.Win32.UI.Controls.Apis.OpenThemeData : return...IntPtr => HTHEME
 Windows.Win32.UI.Controls.Apis.OpenThemeDataEx : return...IntPtr => HTHEME
 Windows.Win32.UI.Controls.HTHEME added
 Windows.Win32.UI.HiDpi.Apis.OpenThemeDataForDpi : return...IntPtr => HTHEME
+# SHGSI_FLAGS
+Windows.Win32.UI.Shell.Apis.SHGetStockIconInfo : uFlags...UInt32 => SHGSI_FLAGS
+Windows.Win32.UI.Shell.Apis.SHGSI_ICONLOCATION removed
+Windows.Win32.UI.Shell.SHGSI_FLAGS added
+Windows.Win32.UI.Shell.SHGSI_FLAGS.SHGSI_ICON added
+Windows.Win32.UI.Shell.SHGSI_FLAGS.SHGSI_ICONLOCATION added
+Windows.Win32.UI.Shell.SHGSI_FLAGS.SHGSI_LARGEICON added
+Windows.Win32.UI.Shell.SHGSI_FLAGS.SHGSI_LINKOVERLAY added
+Windows.Win32.UI.Shell.SHGSI_FLAGS.SHGSI_SELECTED added
+Windows.Win32.UI.Shell.SHGSI_FLAGS.SHGSI_SHELLICONSIZE added
+Windows.Win32.UI.Shell.SHGSI_FLAGS.SHGSI_SMALLICON added
+Windows.Win32.UI.Shell.SHGSI_FLAGS.SHGSI_SYSICONINDEX added


### PR DESCRIPTION
Fixes: #1283

Metadata diff:
```
Windows.Win32.UI.Shell.Apis.SHGetStockIconInfo : uFlags...UInt32 => SHGSI_FLAGS
Windows.Win32.UI.Shell.Apis.SHGSI_ICONLOCATION removed
Windows.Win32.UI.Shell.SHGSI_FLAGS added
Windows.Win32.UI.Shell.SHGSI_FLAGS.SHGSI_ICON added
Windows.Win32.UI.Shell.SHGSI_FLAGS.SHGSI_ICONLOCATION added
Windows.Win32.UI.Shell.SHGSI_FLAGS.SHGSI_LARGEICON added
Windows.Win32.UI.Shell.SHGSI_FLAGS.SHGSI_LINKOVERLAY added
Windows.Win32.UI.Shell.SHGSI_FLAGS.SHGSI_SELECTED added
Windows.Win32.UI.Shell.SHGSI_FLAGS.SHGSI_SHELLICONSIZE added
Windows.Win32.UI.Shell.SHGSI_FLAGS.SHGSI_SMALLICON added
Windows.Win32.UI.Shell.SHGSI_FLAGS.SHGSI_SYSICONINDEX added
```