### PR TITLE
Adjust DEVMODE structure fields

### DIFF
--- a/generation/WinSDK/enums.json
+++ b/generation/WinSDK/enums.json
@@ -31602,6 +31602,7 @@
   },
   {
     "name": "DEVMODE_COLOR",
+    "type": "ushort",
     "autoPopulate": {
       "filter": "DMCOLOR_",
       "header": "wingdi.h"
@@ -31620,6 +31621,7 @@
   },
   {
     "name": "DEVMODE_DUPLEX",
+    "type": "ushort",
     "autoPopulate": {
       "filter": "DMDUP_",
       "header": "wingdi.h"
@@ -31628,16 +31630,17 @@
     "uses": [
       {
         "struct": "DEVMODEW",
-        "field": "dmColor"
+        "field": "dmDuplex"
       },
       {
         "struct": "DEVMODEA",
-        "field": "dmColor"
+        "field": "dmDuplex"
       }
     ]
   },
   {
     "name": "DEVMODE_COLLATE",
+    "type": "ushort",
     "autoPopulate": {
       "filter": "DMCOLLATE_",
       "header": "wingdi.h"
@@ -31655,7 +31658,44 @@
     ]
   },
   {
+    "name": "DEVMODE_DISPLAY_ORIENTATION",
+    "autoPopulate": {
+      "filter": "DMDO_",
+      "header": "wingdi.h"
+    },
+    "members": [],
+    "uses": [
+      {
+        "struct": "DEVMODEW::_Anonymous1_e__Union::_Anonymous2_e__Struct",
+        "field": "dmDisplayOrientation"
+      },
+      {
+        "struct": "DEVMODEA::_Anonymous1_e__Union::_Anonymous2_e__Struct",
+        "field": "dmDisplayOrientation"
+      }
+    ]
+  },
+  {
+    "name": "DEVMODE_DISPLAY_FIXED_OUTPUT",
+    "autoPopulate": {
+      "filter": "DMDFO_",
+      "header": "wingdi.h"
+    },
+    "members": [],
+    "uses": [
+      {
+        "struct": "DEVMODEW::_Anonymous1_e__Union::_Anonymous2_e__Struct",
+        "field": "dmDisplayFixedOutput"
+      },
+      {
+        "struct": "DEVMODEA::_Anonymous1_e__Union::_Anonymous2_e__Struct",
+        "field": "dmDisplayFixedOutput"
+      }
+    ]
+  },
+  {
     "name": "DEVMODE_TRUETYPE_OPTION",
+    "type": "ushort",
     "autoPopulate": {
       "filter": "DMTT_",
       "header": "wingdi.h"

--- a/scripts/ChangesSinceLastRelease.txt
+++ b/scripts/ChangesSinceLastRelease.txt
@@ -2129,3 +2129,30 @@ Windows.Win32.System.EventLog.EVT_SEEK_FLAGS.value__...System.Int32 => System.UI
 Windows.Win32.System.EventLog.EVT_SUBSCRIBE_CALLBACK.Invoke : Event...IntPtr => EVT_HANDLE
 Windows.Win32.System.EventLog.EVT_SUBSCRIBE_FLAGS.value__...System.Int32 => System.UInt32
 Windows.Win32.System.EventLog.EVT_VARIANT._Anonymous_e__Union.EvtHandleVal...System.IntPtr => Windows.Win32.System.EventLog.EVT_HANDLE
+# Tweaks to DEVMODE structures
+Windows.Win32.Graphics.Gdi.Apis.DMDFO_CENTER removed
+Windows.Win32.Graphics.Gdi.Apis.DMDFO_DEFAULT removed
+Windows.Win32.Graphics.Gdi.Apis.DMDFO_STRETCH removed
+Windows.Win32.Graphics.Gdi.Apis.DMDO_180 removed
+Windows.Win32.Graphics.Gdi.Apis.DMDO_270 removed
+Windows.Win32.Graphics.Gdi.Apis.DMDO_90 removed
+Windows.Win32.Graphics.Gdi.Apis.DMDO_DEFAULT removed
+Windows.Win32.Graphics.Gdi.DEVMODE_COLLATE.value__...System.UInt32 => System.UInt16
+Windows.Win32.Graphics.Gdi.DEVMODE_COLOR.value__...System.UInt32 => System.UInt16
+Windows.Win32.Graphics.Gdi.DEVMODE_DUPLEX.value__...System.UInt32 => System.UInt16
+Windows.Win32.Graphics.Gdi.DEVMODE_TRUETYPE_OPTION.value__...System.UInt32 => System.UInt16
+Windows.Win32.Graphics.Gdi.DEVMODEA._Anonymous1_e__Union._Anonymous2_e__Struct.dmDisplayFixedOutput...System.UInt32 => Windows.Win32.System.SystemServices.DEVMODE_DISPLAY_FIXED_OUTPUT
+Windows.Win32.Graphics.Gdi.DEVMODEA._Anonymous1_e__Union._Anonymous2_e__Struct.dmDisplayOrientation...System.UInt32 => Windows.Win32.System.SystemServices.DEVMODE_DISPLAY_ORIENTATION
+Windows.Win32.Graphics.Gdi.DEVMODEA.dmDuplex...System.Int16 => Windows.Win32.Graphics.Gdi.DEVMODE_DUPLEX
+Windows.Win32.Graphics.Gdi.DEVMODEW._Anonymous1_e__Union._Anonymous2_e__Struct.dmDisplayFixedOutput...System.UInt32 => Windows.Win32.System.SystemServices.DEVMODE_DISPLAY_FIXED_OUTPUT
+Windows.Win32.Graphics.Gdi.DEVMODEW._Anonymous1_e__Union._Anonymous2_e__Struct.dmDisplayOrientation...System.UInt32 => Windows.Win32.System.SystemServices.DEVMODE_DISPLAY_ORIENTATION
+Windows.Win32.Graphics.Gdi.DEVMODEW.dmDuplex...System.Int16 => Windows.Win32.Graphics.Gdi.DEVMODE_DUPLEX
+Windows.Win32.System.SystemServices.DEVMODE_DISPLAY_FIXED_OUTPUT added
+Windows.Win32.System.SystemServices.DEVMODE_DISPLAY_FIXED_OUTPUT.DMDFO_CENTER added
+Windows.Win32.System.SystemServices.DEVMODE_DISPLAY_FIXED_OUTPUT.DMDFO_DEFAULT added
+Windows.Win32.System.SystemServices.DEVMODE_DISPLAY_FIXED_OUTPUT.DMDFO_STRETCH added
+Windows.Win32.System.SystemServices.DEVMODE_DISPLAY_ORIENTATION added
+Windows.Win32.System.SystemServices.DEVMODE_DISPLAY_ORIENTATION.DMDO_180 added
+Windows.Win32.System.SystemServices.DEVMODE_DISPLAY_ORIENTATION.DMDO_270 added
+Windows.Win32.System.SystemServices.DEVMODE_DISPLAY_ORIENTATION.DMDO_90 added
+Windows.Win32.System.SystemServices.DEVMODE_DISPLAY_ORIENTATION.DMDO_DEFAULT added


### PR DESCRIPTION
Fixes: #1325

Sample from original reporter, tweaked to validate the struct:
```rust
use windows::Win32::Graphics::Gdi::*;
fn main() {
    let mut dm = DEVMODEA::default();
    dm.dmSize = std::mem::size_of_val(&dm) as u16;
    assert_eq!(dm.dmSize, 156);

    let b = unsafe {
        EnumDisplaySettingsExA(
            windows::core::PCSTR::null(),
            ENUM_CURRENT_SETTINGS,
            &mut dm,
            0u32,
        )
    };

    println!("Result: {:?}", b);
    println!("dm.dmSize: {:?}", dm.dmSize);
    println!("dmBitsPerPel: {:?}", dm.dmBitsPerPel);
    println!("dmPelsWidth: {:?}", dm.dmPelsWidth);
    println!("dmPelsHeight: {:?}", dm.dmPelsHeight);
    println!("dmDisplayFrequency: {:?}", dm.dmDisplayFrequency);
    println!("others");
    println!("dmSpecVersion: {:?}", dm.dmSpecVersion);
    println!("dmDriverVersion: {:?}", dm.dmDriverVersion);
    println!("dmDriverExtra: {:?}", dm.dmDriverExtra);
    println!("dmLogPixels: {:?}", dm.dmLogPixels);
    println!("dmICMMethod: {:?}", dm.dmICMMethod);
}
```
```
Result: BOOL(1)
dm.dmSize: 156
dmBitsPerPel: 32
dmPelsWidth: 5120
dmPelsHeight: 1440
dmDisplayFrequency: 120
others
dmSpecVersion: 1025
dmDriverVersion: 1025
dmDriverExtra: 0
dmLogPixels: 0
dmICMMethod: 0
```