### PR TITLE
Add enum for OLEIVERB

### DIFF
--- a/generation/WinSDK/enums.json
+++ b/generation/WinSDK/enums.json
@@ -663,6 +663,21 @@
     ]
   },
   {
+    "name": "OLEIVERB",
+    "type": "int",
+    "autoPopulate": {
+      "filter": "OLEIVERB_",
+      "header": "Ole2.h"
+    },
+    "members": [],
+    "uses": [
+      {
+        "struct": "OLEVERB",
+        "field": "lVerb"
+      }
+    ]
+  },
+  {
     "name": "POINTER_FLAGS",
     "flags": true,
     "autoPopulate": {

--- a/scripts/ChangesSinceLastRelease.txt
+++ b/scripts/ChangesSinceLastRelease.txt
@@ -53,3 +53,20 @@ Windows.Win32.Devices.Display.Apis.DestroyPhysicalMonitor : return...Int32 => BO
 Windows.Win32.Devices.Display.Apis.DestroyPhysicalMonitors : return...Int32 => BOOL
 Windows.Win32.Devices.Display.Apis.GetNumberOfPhysicalMonitorsFromHMONITOR : return...Int32 => BOOL
 Windows.Win32.Devices.Display.Apis.GetPhysicalMonitorsFromHMONITOR : return...Int32 => BOOL
+# Added enum for OLEIVERB
+Windows.Win32.System.Ole.Apis.OLEIVERB_DISCARDUNDOSTATE removed
+Windows.Win32.System.Ole.Apis.OLEIVERB_HIDE removed
+Windows.Win32.System.Ole.Apis.OLEIVERB_INPLACEACTIVATE removed
+Windows.Win32.System.Ole.Apis.OLEIVERB_OPEN removed
+Windows.Win32.System.Ole.Apis.OLEIVERB_PRIMARY removed
+Windows.Win32.System.Ole.Apis.OLEIVERB_SHOW removed
+Windows.Win32.System.Ole.Apis.OLEIVERB_UIACTIVATE removed
+Windows.Win32.System.Ole.OLEIVERB added
+Windows.Win32.System.Ole.OLEIVERB.OLEIVERB_DISCARDUNDOSTATE added
+Windows.Win32.System.Ole.OLEIVERB.OLEIVERB_HIDE added
+Windows.Win32.System.Ole.OLEIVERB.OLEIVERB_INPLACEACTIVATE added
+Windows.Win32.System.Ole.OLEIVERB.OLEIVERB_OPEN added
+Windows.Win32.System.Ole.OLEIVERB.OLEIVERB_PRIMARY added
+Windows.Win32.System.Ole.OLEIVERB.OLEIVERB_SHOW added
+Windows.Win32.System.Ole.OLEIVERB.OLEIVERB_UIACTIVATE added
+Windows.Win32.System.Ole.OLEVERB.lVerb...System.Int32 => Windows.Win32.System.Ole.OLEIVERB


### PR DESCRIPTION
Fixes #1146

```
Unknown differences found:
Windows.Win32.System.Ole.Apis.OLEIVERB_DISCARDUNDOSTATE removed
Windows.Win32.System.Ole.Apis.OLEIVERB_HIDE removed
Windows.Win32.System.Ole.Apis.OLEIVERB_INPLACEACTIVATE removed
Windows.Win32.System.Ole.Apis.OLEIVERB_OPEN removed
Windows.Win32.System.Ole.Apis.OLEIVERB_PRIMARY removed
Windows.Win32.System.Ole.Apis.OLEIVERB_SHOW removed
Windows.Win32.System.Ole.Apis.OLEIVERB_UIACTIVATE removed
Windows.Win32.System.Ole.OLEIVERB added
Windows.Win32.System.Ole.OLEIVERB.OLEIVERB_DISCARDUNDOSTATE added
Windows.Win32.System.Ole.OLEIVERB.OLEIVERB_HIDE added
Windows.Win32.System.Ole.OLEIVERB.OLEIVERB_INPLACEACTIVATE added
Windows.Win32.System.Ole.OLEIVERB.OLEIVERB_OPEN added
Windows.Win32.System.Ole.OLEIVERB.OLEIVERB_PRIMARY added
Windows.Win32.System.Ole.OLEIVERB.OLEIVERB_SHOW added
Windows.Win32.System.Ole.OLEIVERB.OLEIVERB_UIACTIVATE added
Windows.Win32.System.Ole.OLEVERB.lVerb...System.Int32 => Windows.Win32.System.Ole.OLEIVERB
```