### PR TITLE
Fix method counting for interfaces when scanning references

### DIFF
--- a/sources/ClangSharpSourceToWinmd/ClangSharpSourceWinmdGenerator.cs
+++ b/sources/ClangSharpSourceToWinmd/ClangSharpSourceWinmdGenerator.cs
@@ -429,7 +429,7 @@ namespace ClangSharpSourceToWinmd
             if (symbol != null)
             {
                 this.interfaceSymbols.Add(symbol);
-                this.interfaceMethodCount[symbol] = interfaceInfo.Methods.Count();
+                this.interfaceMethodCount[symbol] = interfaceInfo.ImplementedMethodCount;
                 if (!this.namesToInterfaceSymbols.TryGetValue(symbol.Name, out var symbols))
                 {
                     symbols = new List<ISymbol>();

--- a/tests/MetadataUtils.Tests/WinmdUtilsTests.cs
+++ b/tests/MetadataUtils.Tests/WinmdUtilsTests.cs
@@ -1,0 +1,53 @@
+﻿using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace MetadataUtils.Tests
+{
+    public interface IBase { void A(); };
+    public interface IFoo { void B(); }
+    public interface IBar : IBase { void C(); }
+    public interface IQux : IFoo, IBar { void D(); }
+
+    public class WinmdUtilsTests
+    {
+        [Fact]
+        public void GetTypes_MultipleInterfacesPresent_CorrectNumberOfMethodsReturned()
+        {
+            // Arrange
+
+            // Act
+            using var metadata = WinmdUtils.LoadFromFile(Assembly.GetExecutingAssembly().Location);
+            var typeInfo = metadata.GetTypes().First(t => t.Name == "IQux") as InterfaceInfo;
+
+            // Assert
+            Assert.Equal(4, typeInfo.ImplementedMethodCount);
+        }
+
+        [Fact]
+        public void GetTypes_InterfaceHeirarchyNotPresent_CorrectNumberOfMethodsReturned()
+        {
+            // Arrange
+
+            // Act
+            using var metadata = WinmdUtils.LoadFromFile(Assembly.GetExecutingAssembly().Location);
+            var typeInfo = metadata.GetTypes().First(t => t.Name == "IFoo") as InterfaceInfo;
+
+            // Assert
+            Assert.Equal(1, typeInfo.ImplementedMethodCount);
+        }
+
+        [Fact]
+        public void GetTypes_InterfaceHeirarchyPresent_CorrectNumberOfMethodsReturned()
+        {
+            // Arrange
+
+            // Act
+            using var metadata = WinmdUtils.LoadFromFile(Assembly.GetExecutingAssembly().Location);
+            var typeInfo = metadata.GetTypes().First(t => t.Name == "IBar") as InterfaceInfo;
+
+            // Assert
+            Assert.Equal(2, typeInfo.ImplementedMethodCount);
+        }
+    }
+}


### PR DESCRIPTION
`ClangSharpSourceWinmdGenerator` maintains a cache of encountered interface types and their method counts. This information is currently obtained during two phases:
1. a walk of input syntax trees
2. a walk of compilation references

The input syntax trees (1) contain interface types with all inherited and local methods already emitted. When `ClangSharpSourceWinmdGenerator` performs a `MethodDeclarationSyntax` count, it caches the correct value.

Example input fragment:
```csharp
[NativeInheritance("IInspectable")]
public unsafe partial struct IDragDropManagerInterop
{
  public delegate int _QueryInterface(IDragDropManagerInterop* pThis, [NativeTypeName("const IID &"),Const]Guid* riid, [ComOutPtr]void** ppvObject);
  public delegate uint _AddRef(IDragDropManagerInterop* pThis);
  public delegate uint _Release(IDragDropManagerInterop* pThis);
  ...
}
```

The compilation references (2) (e.g. Windows.Win32.winmd) however contain interface types that do not have these methods emitted. `ClangSharpSourceWinmdGenerator` instead counts the number of methods on the type specified by `NativeInheritance` and moves on, resulting in an inaccurate count. This count is used later to skip over inherited methods when emitting interface method metadata, resulting in interfaces with invalid method members.

Example:
```csharp
public interface IFoo : IInspectable
{
  // 3 IUnknown methods skipped over

  // 3 IInspectable methods that didn't get skipped over
  unsafe HRESULT GetIids(...);
  unsafe HRESULT GetRuntimeClassName(...);
  unsafe HRESULT GetTrustLevel(...);
  unsafe HRESULT IFooFirstMethod(...);
}
```

This impacts all projects with references to Windows.Win32.winmd and using the Microsoft.Windows.WinmdGenerator to generate metadata. (Generally everyone outside of win32metadata.)

This PR fixes method counting during the compilation reference walk by also counting the methods for each interface implemented by an interface type. This information is obtained via the `InterfaceImpl` table (`II.22.23`).

Fixes: #1426 
