### PR TITLE
removing conditional filters for unsafe code property

### DIFF
--- a/sources/MetadataUtils/MetadataUtils.csproj
+++ b/sources/MetadataUtils/MetadataUtils.csproj
@@ -8,11 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+  <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 

--- a/sources/Win32MetadataInterop/Win32MetadataInterop.csproj
+++ b/sources/Win32MetadataInterop/Win32MetadataInterop.csproj
@@ -4,16 +4,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <RootNamespace>Windows.Win32.Interop</RootNamespace>
     <AssemblyName>Windows.Win32.Interop</AssemblyName>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>1701;1702;0649</NoWarn>
   </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <NoWarn>1701;1702;0649</NoWarn>
-  </PropertyGroup>
-
 </Project>


### PR DESCRIPTION
I regularly run into build issues where the build filters resolve to false on two (of three) projects that rely on the AllowUnsafeCode property, resulting in build failures. This change just removes the conditions to make the build more reliable on local machines.