### PR TITLE
Correct BITMAPINFOHEADER.biCompression type

### DIFF
--- a/generation/WinSDK/enums.json
+++ b/generation/WinSDK/enums.json
@@ -30917,10 +30917,6 @@
         "field": "bV5Compression"
       },
       {
-        "struct": "BITMAPINFOHEADER",
-        "field": "biCompression"
-      },
-      {
         "struct": "BITMAPV4HEADER",
         "field": "bV4V4Compression"
       }

--- a/scripts/ChangesSinceLastRelease.txt
+++ b/scripts/ChangesSinceLastRelease.txt
@@ -107,3 +107,5 @@ Windows.Win32.Devices.HumanInterfaceDevice.Apis.HIDP_STATUS_REPORT_DOES_NOT_EXIS
 Windows.Win32.Devices.HumanInterfaceDevice.Apis.HIDP_STATUS_SUCCESS added
 Windows.Win32.Devices.HumanInterfaceDevice.Apis.HIDP_STATUS_USAGE_NOT_FOUND added
 Windows.Win32.Devices.HumanInterfaceDevice.Apis.HIDP_STATUS_VALUE_OUT_OF_RANGE added
+# Correct BITMAPINFOHEADER.biCompression type
+Windows.Win32.Graphics.Gdi.BITMAPINFOHEADER.biCompression...Windows.Win32.Graphics.Gdi.BI_COMPRESSION => System.UInt32


### PR DESCRIPTION
Per docs (https://learn.microsoft.com/windows/win32/api/wingdi/ns-wingdi-bitmapinfoheader):
> biCompression
> For compressed video and YUV formats, this member is a FOURCC code, specified as a DWORD in little-endian order. For example, YUYV video has the FOURCC 'VYUY' or 0x56595559.


Fixes: #1442 

Metadata diff:
```
Windows.Win32.Graphics.Gdi.BITMAPINFOHEADER.biCompression...Windows.Win32.Graphics.Gdi.BI_COMPRESSION => System.UInt32
```