### PR TITLE
Mark `DXGI_SWAP_CHAIN_DESC1::Flags` as `DXGI_SWAP_CHAIN_FLAG` type

### DIFF
--- a/generation/WinSDK/emitter.settings.rsp
+++ b/generation/WinSDK/emitter.settings.rsp
@@ -1302,7 +1302,7 @@ D3D12_ROOT_SIGNATURE_DESC1::pStaticSamplers=[NativeArrayInfo(CountFieldName = "N
 D3D12_STREAM_OUTPUT_DESC::pBufferStrides=[NativeArrayInfo(CountFieldName = "NumStrides")]
 D3D12_STREAM_OUTPUT_DESC::pSODeclaration=[NativeArrayInfo(CountFieldName = "NumEntries")]
 D3D12_VIEW_INSTANCING_DESC::pViewInstanceLocations=[NativeArrayInfo(CountFieldName = "ViewInstanceCount")]
-DXGI_SWAP_CHAIN_DESC1::Flags=DXGI_SWAP_CHAIN_FLAG
+DXGI_SWAP_CHAIN_DESC1::Flags=[AssociatedEnum("DXGI_SWAP_CHAIN_FLAG")]
 CreatePipe::hReadPipe=[IgnoreIfReturn("0")]
 CreatePipe::hWritePipe=[IgnoreIfReturn("0")]
 MapViewOfFile::return=MEMORY_MAPPED_VIEW_ADDRESS

--- a/generation/WinSDK/emitter.settings.rsp
+++ b/generation/WinSDK/emitter.settings.rsp
@@ -1302,6 +1302,7 @@ D3D12_ROOT_SIGNATURE_DESC1::pStaticSamplers=[NativeArrayInfo(CountFieldName = "N
 D3D12_STREAM_OUTPUT_DESC::pBufferStrides=[NativeArrayInfo(CountFieldName = "NumStrides")]
 D3D12_STREAM_OUTPUT_DESC::pSODeclaration=[NativeArrayInfo(CountFieldName = "NumEntries")]
 D3D12_VIEW_INSTANCING_DESC::pViewInstanceLocations=[NativeArrayInfo(CountFieldName = "ViewInstanceCount")]
+DXGI_SWAP_CHAIN_DESC1::Flags=DXGI_SWAP_CHAIN_FLAG
 CreatePipe::hReadPipe=[IgnoreIfReturn("0")]
 CreatePipe::hWritePipe=[IgnoreIfReturn("0")]
 MapViewOfFile::return=MEMORY_MAPPED_VIEW_ADDRESS

--- a/scripts/ChangesSinceLastRelease.txt
+++ b/scripts/ChangesSinceLastRelease.txt
@@ -433,3 +433,5 @@ winmd1: Windows.Win32.System.Diagnostics.ClrProfiling.COR_PRF_HIGH_MONITOR.COR_P
 winmd1: Windows.Win32.System.Diagnostics.ClrProfiling.COR_PRF_HIGH_MONITOR.COR_PRF_HIGH_MONITOR_IMMUTABLE = 0, winmd2 = 8
 winmd1: Windows.Win32.System.Diagnostics.ClrProfiling.COR_PRF_MONITOR.COR_PRF_ALLOWABLE_AFTER_ATTACH = 268501758, winmd2 = 268763902
 winmd1: Windows.Win32.System.Diagnostics.ClrProfiling.COR_PRF_MONITOR.COR_PRF_MONITOR_IMMUTABLE = -285422592, winmd2 = -285684736
+# Turn DXGI_SWAP_CHAIN_DESC1.Flags into DXGI_SWAP_CHAIN_FLAG type
+Windows.Win32.Graphics.Dxgi.DXGI_SWAP_CHAIN_DESC1.Flags :  => [AssociatedEnum(DXGI_SWAP_CHAIN_FLAG)]


### PR DESCRIPTION
This is currently a `UINT` followed by a comment stating the actual enumeration type that contains the possible flag bits.
