### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @mikebattista @chenss3
+* @mikebattista


### PR DESCRIPTION
@mikebattista Is Sophia still working on win32metadata? If not, we can cleanup the `CODEOWNERS` file and get GitHub to stop bubbling up through the reviewer UI/etc.