### PR TITLE
Include nested types when identifying namespace dependencies

### DIFF
--- a/sources/MetadataUtils/NamespaceDependencyUtil.cs
+++ b/sources/MetadataUtils/NamespaceDependencyUtil.cs
@@ -45,8 +45,11 @@ namespace MetadataUtils
             {
                 DecompilerTypeSystem winmd1 = DecompilerTypeSystemUtils.CreateTypeSystemFromFile(winmdFileName);
 
-                foreach (var type1 in winmd1.GetTopLevelTypeDefinitions())
+                var types = new Queue<ITypeDefinition>(winmd1.GetTopLevelTypeDefinitions());
+                while (types.Any())
                 {
+                    var type1 = types.Dequeue();
+
                     if (type1.FullName == "<Module>")
                     {
                         continue;
@@ -70,6 +73,14 @@ namespace MetadataUtils
                         {
                             string broughtInBy = $"{type1.Name}.{field.Name}";
                             this.AddTypeDependency(type1, depends, broughtInBy, field.Type);
+                        }
+
+                        foreach (var nested in type1.GetNestedTypes())
+                        {
+                            var def = nested.GetDefinition();
+                            if (def != null) {
+                                types.Enqueue(def);
+                            }
                         }
                     }
                     else if (type1.Kind == TypeKind.Class && type1.Name == "Apis")


### PR DESCRIPTION
When running the `WinmdUtils` tool with the `showNamespaceDependencies` or `showNamespaceCycles` commands, only top-level type definitions are currently processed by the dependency search logic. Dependencies that exist in nested types are missed, as are any cyclic dependencies between namespaces that arise from them.

This pull request updates the search logic to process nested types that are enclosed within top-level type definitions for native structs and unions (both of which are represented as CLR structs in the metadata). This provides a more complete picture of the dependencies between namespaces, and exposes a number of cyclic dependencies that were not previously reported by the tool.

Here's the output of running the `showNamespaceCycles` command against the metadata file from the [56.0.13-preview](https://www.nuget.org/packages/Microsoft.Windows.SDK.Win32Metadata/56.0.13-preview) release, using the existing search logic:

```
WinmdUtils> dotnet run showNamespaceCycles --winmd Windows.Win32.winmd

No cycles found between any namespaces.
```

Here's the output after applying the changes from this pull request:

```
WinmdUtils> dotnet run showNamespaceCycles --winmd Windows.Win32.winmd

Windows.Win32.Media
  Cyclical dependent namespaces: Windows.Win32.System.Ole
Windows.Win32.Security.Cryptography.Catalog
  Cyclical dependent namespaces: Windows.Win32.Security.Cryptography.Sip
Windows.Win32.Security.Cryptography.Sip
  Cyclical dependent namespaces: Windows.Win32.Security.Cryptography.Catalog
Windows.Win32.System.Com
  Cyclical dependent namespaces: Windows.Win32.System.Variant, Windows.Win32.Media, Windows.Win32.System.Ole, Windows.Win32.System.Com.StructuredStorage, Windows.Win32.System.SystemServices, Windows.Win32.UI.Controls, Windows.Win32.UI.Controls.Dialogs
Windows.Win32.System.Com.StructuredStorage
  Cyclical dependent namespaces: Windows.Win32.System.Com, Windows.Win32.System.Ole
Windows.Win32.System.Ole
  Cyclical dependent namespaces: Windows.Win32.System.Variant, Windows.Win32.System.Com
Windows.Win32.System.SystemServices
  Cyclical dependent namespaces: Windows.Win32.System.Ole, Windows.Win32.System.Com
Windows.Win32.System.Variant
  Cyclical dependent namespaces: Windows.Win32.System.Com.StructuredStorage, Windows.Win32.System.Ole, Windows.Win32.System.Com
Windows.Win32.UI.Controls
  Cyclical dependent namespaces: Windows.Win32.System.Ole, Windows.Win32.UI.Controls.Dialogs, Windows.Win32.UI.Input.Pointer
Windows.Win32.UI.Controls.Dialogs
  Cyclical dependent namespaces: Windows.Win32.System.Ole
Windows.Win32.UI.Input.Pointer
  Cyclical dependent namespaces: Windows.Win32.UI.Controls
```