### PR TITLE
fix: IoRing return types

### DIFF
--- a/generation/WinSDK/emitter.settings.rsp
+++ b/generation/WinSDK/emitter.settings.rsp
@@ -1798,3 +1798,4 @@ IShellFolder2::GetDefaultColumnState::pcsFlags=SHCOLSTATE
 IShellFolder::CompareIDs=[CanReturnMultipleSuccessValues]
 WriteConsoleA::lpBuffer=PSTR
 WriteConsoleW::lpBuffer=PWSTR
+PopIoRingCompletion=[CanReturnMultipleSuccessValues]

--- a/scripts/ChangesSinceLastRelease.txt
+++ b/scripts/ChangesSinceLastRelease.txt
@@ -1,0 +1,2 @@
+# fix IoRing api results
+Windows.Win32.Storage.FileSystem.Apis.PopIoRingCompletion : [DllImport(api-ms-win-core-ioring-l1-1-0.dll,ExactSpelling=True,PreserveSig=False),Documentation(https://learn.microsoft.com/windows/win32/api/ioringapi/nf-ioringapi-popioringcompletion)] => [CanReturnMultipleSuccessValues,DllImport(api-ms-win-core-ioring-l1-1-0.dll,ExactSpelling=True,PreserveSig=False),Documentation(https://learn.microsoft.com/windows/win32/api/ioringapi/nf-ioringapi-popioringcompletion)]


### PR DESCRIPTION
This commit fixes the IoRing function return types. `PopIoRingCompletion` function has multiple success values which should be reflected in the metadata.