### PR TITLE
CryptUIWizDigitalSign sets the last error on failure.

### DIFF
--- a/generation/WinSDK/WithSetLastError.rsp
+++ b/generation/WinSDK/WithSetLastError.rsp
@@ -677,6 +677,7 @@ CryptStringToBinaryA
 CryptStringToBinaryW
 CryptUIDlgViewCertificateA
 CryptUIDlgViewCertificateW
+CryptUIWizDigitalSign
 CryptUIWizExport
 CryptUIWizImport
 CryptUninstallDefaultContext

--- a/scripts/ChangesSinceLastRelease.txt
+++ b/scripts/ChangesSinceLastRelease.txt
@@ -291,3 +291,5 @@ Windows.Win32.UI.WindowsAndMessaging.Apis.SendMessageTimeoutW : [DllImport(USER3
 # Fixed #1866.
 Windows.Win32.System.WinRT.Printing.IPrintDocumentPageSource added
 Windows.Win32.System.WinRT.Printing.IPrintPreviewPageCollection added
+# CryptUIWizDigitalSign sets the last error on failure.
+Windows.Win32.Security.Cryptography.UI.Apis.CryptUIWizDigitalSign : [DllImport(CRYPTUI.dll,ExactSpelling=True,PreserveSig=False),Documentation(https://learn.microsoft.com/windows/win32/api/cryptuiapi/nf-cryptuiapi-cryptuiwizdigitalsign),SupportedOSPlatform(windows5.1.2600)] => [DllImport(CRYPTUI.dll,ExactSpelling=True,PreserveSig=False,SetLastError=True),Documentation(https://learn.microsoft.com/windows/win32/api/cryptuiapi/nf-cryptuiapi-cryptuiwizdigitalsign),SupportedOSPlatform(windows5.1.2600)]


### PR DESCRIPTION
I've also requested an update to the ms docs:
https://github.com/MicrosoftDocs/sdk-api/pull/1801/files

Thank you.