### PR TITLE
Add references for all assemblies passed in via `--ref`

### DIFF
--- a/sources/ClangSharpSourceToWinmd/ClangSharpSourceWinmdGenerator.cs
+++ b/sources/ClangSharpSourceToWinmd/ClangSharpSourceWinmdGenerator.cs
@@ -144,31 +144,17 @@ namespace ClangSharpSourceToWinmd
 
             void InitReferences()
             {
-                Version systemVersion = new Version(2, 1, 0, 0);
-                var netstandardAssembly = this.compilation.ReferencedAssemblyNames.ToList().Find(a => a.Name == SystemAssemblyName);
-                var systemAssemblyRef =
-                    this.metadataBuilder.AddAssemblyReference(
-                        this.metadataBuilder.GetOrAddString(netstandardAssembly.Name),
-                        netstandardAssembly.Version,
-                        default,
-                        this.metadataBuilder.GetOrAddBlob(netstandardAssembly.PublicKeyToken),
-                        default,
-                        default);
-                this.assemblyNamesToRefHandles[SystemAssemblyName] = systemAssemblyRef;
-
-                var win32Assembly = this.compilation.ReferencedAssemblyNames.ToList().Find(a => a.Name == Win32MetadataAssemblyName);
-                if (win32Assembly != null)
+                foreach (var assembly in this.compilation.ReferencedAssemblyNames)
                 {
-                    var win32MetadataAssemblyRef =
+                    var assemblyRef =
                         this.metadataBuilder.AddAssemblyReference(
-                            this.metadataBuilder.GetOrAddString(win32Assembly.Name),
-                            win32Assembly.Version,
+                            this.metadataBuilder.GetOrAddString(assembly.Name),
+                            assembly.Version,
                             default,
-                            this.metadataBuilder.GetOrAddBlob(win32Assembly.PublicKeyToken),
+                            this.metadataBuilder.GetOrAddBlob(assembly.PublicKeyToken),
                             default,
                             default);
-
-                    this.assemblyNamesToRefHandles[Win32MetadataAssemblyName] = win32MetadataAssemblyRef;
+                    this.assemblyNamesToRefHandles[assembly.Name] = assemblyRef;
                 }
             }
         }


### PR DESCRIPTION
While trying to generate my own bindings, `ClangSharpSourceToWinmd` was reporting the following error:

```
error CS0648: '' is a type not supported by the language
```

I tracked it down to a method in the current compilation using a struct from a referenced WinMD (let's call this "Middle.winmd") which had a field from another WinMD (let's call it "Base.winmd"). Looking at the winmd files in ildasm, Middle.winmd was missing a reference to Base.winmd, so there was no way for the current compilation to know where referenced types came from, despite the current compilation referencing both Middle.winmd and Base.winmd.

The fix for this is to add an assembly reference to all assemblies passed in via `--ref`