### PR TITLE
Add an option to ConstantsScraper to import constants from another namespace

### DIFF
--- a/sources/MetadataUtils/ConstantWriter.cs
+++ b/sources/MetadataUtils/ConstantWriter.cs
@@ -270,7 +270,6 @@ $"        [NativeTypeName(\"{nativeTypeName}\")]");
                 this.writer = new StreamWriter(this.outputStream);
                 this.writer.WriteLine(
 @$"{this.headerText}
-
 namespace {this.@namespace}
 {{
     public static partial class Apis


### PR DESCRIPTION
Although `ConstantsScraper` can reference named constants from other header files, if that other header file's constants were placed into a different namespace (e.g., in a different WinMD file) then the C# generated is invalid.

This change adds a new option `--useConstantsFrom` that can be used to generate `using static` declarations for other namespaces that the current C# file may reference.