### PR TITLE
Add additional InvalidHandleValues metadata

### DIFF
--- a/generation/WinSDK/autoTypes.json
+++ b/generation/WinSDK/autoTypes.json
@@ -1365,6 +1365,7 @@
     "Name": "SOCKET",
     "ValueType": "UIntPtr",
     "CloseApi": "closesocket",
+    "InvalidHandleValues": [ -1 ],
     "NativeTypedef": true
   },
   {
@@ -2300,12 +2301,14 @@
     "Name": "PTP_POOL",
     "ValueType": "typedef struct _TP_POOL",
     "CloseApi": "CloseThreadpool",
+    "InvalidHandleValues": [ 0 ],
     "NativeTypedef": true
   },
   {
     "Name": "PTP_CLEANUP_GROUP",
     "ValueType": "typedef struct _TP_CLEANUP_GROUP",
     "CloseApi": "CloseThreadpoolCleanupGroup",
+    "InvalidHandleValues": [ 0 ],
     "NativeTypedef": true
   },
   {
@@ -2498,6 +2501,7 @@
     "Name": "HIORING",
     "ValueType": "DECLARE_HANDLE",
     "CloseApi": "CloseIoRing",
+    "InvalidHandleValues": [ -1, 0 ],
     "NativeTypedef": true
   },
   {

--- a/scripts/ChangesSinceLastRelease.txt
+++ b/scripts/ChangesSinceLastRelease.txt
@@ -291,3 +291,8 @@ Windows.Win32.UI.WindowsAndMessaging.Apis.SendMessageTimeoutW : [DllImport(USER3
 # Fixed #1866.
 Windows.Win32.System.WinRT.Printing.IPrintDocumentPageSource added
 Windows.Win32.System.WinRT.Printing.IPrintPreviewPageCollection added
+# Add additional InvalidHandleValue metadata
+Windows.Win32.Networking.WinSock.SOCKET : [NativeTypedef,RAIIFree(closesocket)] => [InvalidHandleValue(-1),NativeTypedef,RAIIFree(closesocket)]
+Windows.Win32.Storage.FileSystem.HIORING : [NativeTypedef,RAIIFree(CloseIoRing)] => [InvalidHandleValue(-1),InvalidHandleValue(0),NativeTypedef,RAIIFree(CloseIoRing)]
+Windows.Win32.System.Threading.PTP_CLEANUP_GROUP : [NativeTypedef,RAIIFree(CloseThreadpoolCleanupGroup)] => [InvalidHandleValue(0),NativeTypedef,RAIIFree(CloseThreadpoolCleanupGroup)]
+Windows.Win32.System.Threading.PTP_POOL : [NativeTypedef,RAIIFree(CloseThreadpool)] => [InvalidHandleValue(0),NativeTypedef,RAIIFree(CloseThreadpool)]


### PR DESCRIPTION
Addresses missing `InvalidHandleValue` metadata for `RAIIFree`-marked types mentioned in #1891.