### PR TITLE
Fix ConstantsScraper tests

### DIFF
--- a/tests/MetadataUtils.Tests/ConstantsScraperTests.cs
+++ b/tests/MetadataUtils.Tests/ConstantsScraperTests.cs
@@ -86,7 +86,6 @@ namespace MetadataUtils.Tests
             // Assert
             Assert.Collection(mockFileSystem.GetFile("output.txt").TextContents.Split("\n"),
                 e => { },
-                e => { },
                 e => { /* namespace */ },
                 e => { /* { */ },
                 e => { /*   class */ },


### PR DESCRIPTION
#1890 broke the ConstantsScraper tests by removing an extra newline at the beginning of emitted files if there is no header text or `using` declarations to emit.