### PR TITLE
Remove incomplete metadata for ScriptStringAnalyse

### DIFF
--- a/generation/WinSDK/emitter.settings.rsp
+++ b/generation/WinSDK/emitter.settings.rsp
@@ -1852,3 +1852,4 @@ WSACloseEvent::hEvent=WSAEVENT
 WSACreateEvent::return=WSAEVENT
 WSAEnumNetworkEvents::hEventObject=WSAEVENT
 WSAEventSelect::hEventObject=WSAEVENT
+ScriptStringAnalyse::piDx=[-NativeArrayInfo]

--- a/scripts/ChangesSinceLastRelease.txt
+++ b/scripts/ChangesSinceLastRelease.txt
@@ -1,0 +1,2 @@
+# Remove incomplete metadata for ScriptStringAnalyse
+Windows.Win32.Globalization.Apis.ScriptStringAnalyse : piDx : [Const,In,NativeArrayInfo(CountParamIndex=2),Optional] => [Const,In,Optional]


### PR DESCRIPTION
Fixes: #1881

Removes native array information metadata from `ScriptStringAnalyse::piDx`. Further discussion in aforementioned issue thread.