### PR TITLE
When finding a type def from a type ref, search all assemblies

### DIFF
--- a/sources/WinmdUtils/Program.cs
+++ b/sources/WinmdUtils/Program.cs
@@ -417,13 +417,14 @@ namespace WinmdUtilsProgram
 
         public static int ShowPointersToDelegates(FileInfo winmd, string[] allowItem, IConsole console)
         {
+            List<WinmdUtils> allWinmds = new List<WinmdUtils>();
             HashSet<string> allowTable = new HashSet<string>(allowItem);
             using WinmdUtils w1 = WinmdUtils.LoadFromFile(winmd.FullName);
             bool pointersFound = false;
 
-            HashSet<string> delegateNames = new HashSet<string>(w1.GetTypes().Where(t => t is DelegateTypeInfo).Select(d => $"{d.Namespace}.{d.Name}"));
+            HashSet<string> delegateNames = new HashSet<string>(w1.GetTypes(allWinmds).Where(t => t is DelegateTypeInfo).Select(d => $"{d.Namespace}.{d.Name}"));
 
-            foreach (var type in w1.GetTypes())
+            foreach (var type in w1.GetTypes(allWinmds))
             {
                 foreach (var pointerInUse in PointerToOneOfNamesInUse(delegateNames, type))
                 {
@@ -690,10 +691,11 @@ namespace WinmdUtilsProgram
 
         public static int ShowEmptyDelegates(FileInfo winmd, string[] allowItem, IConsole console)
         {
+            List<WinmdUtils> allWinmds = new List<WinmdUtils>();
             HashSet<string> allowTable = new HashSet<string>(allowItem);
             using WinmdUtils w1 = WinmdUtils.LoadFromFile(winmd.FullName);
             bool emptyFound = false;
-            foreach (DelegateTypeInfo type in w1.GetTypes().Where(t => t is DelegateTypeInfo))
+            foreach (DelegateTypeInfo type in w1.GetTypes(allWinmds).Where(t => t is DelegateTypeInfo))
             {
                 if (!type.Parameters.Any())
                 {


### PR DESCRIPTION
We were seeing a crash in `ClangSharpSourceToWinmd` when we had an interface inheriting another interface from a different assembly:
```
3001>Unhandled exception: System.InvalidOperationException: Sequence contains no matching element
3001>   at System.Linq.ThrowHelper.ThrowNoMatchException()
3001>   at System.Linq.Enumerable.First[TSource](IEnumerable`1 source, Func`2 predicate)
3001>   at MetadataUtils.WinmdUtils.InternalGetImplementedMethodCount(TypeDefinition typeDef)
3001>   at MetadataUtils.WinmdUtils.GetTypes()+MoveNext()
3001>   at ClangSharpSourceToWinmd.ClangSharpSourceWinmdGenerator.<PopulateMetadataBuilder>g__GatherInterfaceTypes|60_1()
3001>   at ClangSharpSourceToWinmd.ClangSharpSourceWinmdGenerator.PopulateMetadataBuilder()
3001>   at ClangSharpSourceToWinmd.ClangSharpSourceWinmdGenerator.GenerateWindmdForCompilation(ClangSharpSourceCompilation compilation, Dictionary`2 typeImports, HashSet`1 reducePointerLevels, HashSet`1 forceGuidConsts, Version version, String outputFileName)
3001>   at ClangSharpSourceToWinmd.Program.Run(InvocationContext context)
```

`ClangSharpSourceToWinmd` was only searching for matching named types within the current assembly when it encountered a `TypeReference`, however `TypeReference` is specifically used when referencing a type from a foreign assembly.

This fix for this is to provide the complete set of metadata readers to `GetTypes` so that it can search through all of them to find the type definition for a given `TypeReference`