### PR TITLE
Fix test failures

### DIFF
--- a/sources/WinmdUtils/Program.cs
+++ b/sources/WinmdUtils/Program.cs
@@ -417,9 +417,9 @@ namespace WinmdUtilsProgram
 
         public static int ShowPointersToDelegates(FileInfo winmd, string[] allowItem, IConsole console)
         {
-            List<WinmdUtils> allWinmds = new List<WinmdUtils>();
             HashSet<string> allowTable = new HashSet<string>(allowItem);
             using WinmdUtils w1 = WinmdUtils.LoadFromFile(winmd.FullName);
+            List<WinmdUtils> allWinmds = new List<WinmdUtils>{ w1 };
             bool pointersFound = false;
 
             HashSet<string> delegateNames = new HashSet<string>(w1.GetTypes(allWinmds).Where(t => t is DelegateTypeInfo).Select(d => $"{d.Namespace}.{d.Name}"));
@@ -691,9 +691,9 @@ namespace WinmdUtilsProgram
 
         public static int ShowEmptyDelegates(FileInfo winmd, string[] allowItem, IConsole console)
         {
-            List<WinmdUtils> allWinmds = new List<WinmdUtils>();
             HashSet<string> allowTable = new HashSet<string>(allowItem);
             using WinmdUtils w1 = WinmdUtils.LoadFromFile(winmd.FullName);
+            List<WinmdUtils> allWinmds = new List<WinmdUtils> { w1 };
             bool emptyFound = false;
             foreach (DelegateTypeInfo type in w1.GetTypes(allWinmds).Where(t => t is DelegateTypeInfo))
             {


### PR DESCRIPTION
PR #1919 introduced a test failure since it was passing an empty list for `allWinmds`, fix is to pass a list containing the current WinMD.