### PR TITLE
Add attribute on IPropertyStoreCapabilities::IsPropertyWritable

### DIFF
--- a/generation/WinSDK/emitter.settings.rsp
+++ b/generation/WinSDK/emitter.settings.rsp
@@ -1080,15 +1080,15 @@ SetLogFileSizeWithPolicy::pDesiredSize=[In]
 SetLogFileSizeWithPolicy::pResultingSize=[Out]
 FlushLogBuffers::pvMarshal=[In]
 FlushLogBuffers::pOverlapped=[In][Out][Optional][Retained]
-GetMessageA=[CanReturnMultipleSuccessValuesAttribute]
-GetMessageW=[CanReturnMultipleSuccessValuesAttribute]
+GetMessageA=[CanReturnMultipleSuccessValues]
+GetMessageW=[CanReturnMultipleSuccessValues]
 GetNumberOfPhysicalMonitorsFromHMONITOR::return=BOOL
 GetPhysicalMonitorsFromHMONITOR::return=BOOL
 DestroyPhysicalMonitor::return=BOOL
 DestroyPhysicalMonitors::return=BOOL
 IAudioProcessingObjectConfiguration::LockForProcess::ppInputConnections=[NativeArrayInfo(CountParamIndex = 0)]
 IAudioProcessingObjectConfiguration::LockForProcess::ppOutputConnections=[NativeArrayInfo(CountParamIndex = 2)]
-IUnknown::QueryInterface=[CanReturnErrorsAsSuccessAttribute]
+IUnknown::QueryInterface=[CanReturnErrorsAsSuccess]
 GetPrivateProfileIntW::return=int
 OleCreatePictureIndirect::lplpvObj=[ComOutPtr]
 ContinueDebugEvent::dwContinueStatus=NTSTATUS
@@ -1855,4 +1855,4 @@ WSAEventSelect::hEventObject=WSAEVENT
 ScriptStringAnalyse::piDx=[-NativeArrayInfo]
 LoadIconMetric::hinst=[In][Optional]
 LoadIconWithScaleDown::hinst=[In][Optional]
-IPropertyStoreCapabilities::IsPropertyWritable=[CanReturnMultipleSuccessValuesAttribute]
+IPropertyStoreCapabilities::IsPropertyWritable=[CanReturnMultipleSuccessValues]

--- a/generation/WinSDK/emitter.settings.rsp
+++ b/generation/WinSDK/emitter.settings.rsp
@@ -1855,3 +1855,4 @@ WSAEventSelect::hEventObject=WSAEVENT
 ScriptStringAnalyse::piDx=[-NativeArrayInfo]
 LoadIconMetric::hinst=[In][Optional]
 LoadIconWithScaleDown::hinst=[In][Optional]
+IPropertyStoreCapabilities::IsPropertyWritable=[CanReturnMultipleSuccessValuesAttribute]

--- a/scripts/ChangesSinceLastRelease.txt
+++ b/scripts/ChangesSinceLastRelease.txt
@@ -256,3 +256,5 @@ Windows.Win32.Devices.Nfp.Apis.IOCTL_NFP_GET_NEXT_SUBSCRIBED_MESSAGE added
 Windows.Win32.Devices.Nfp.Apis.IOCTL_NFP_GET_NEXT_TRANSMITTED_MESSAGE added
 Windows.Win32.Devices.Nfp.Apis.IOCTL_NFP_SET_PAYLOAD added
 Windows.Win32.Devices.Nfp.SUBSCRIBED_MESSAGE added
+# Add return attribute on IPropertyStoreCapabilities::IsPropertyWritable
+Windows.Win32.UI.Shell.PropertiesSystem.IPropertyStoreCapabilities.IsPropertyWritable : [Documentation(https://learn.microsoft.com/windows/win32/api/propsys/nf-propsys-ipropertystorecapabilities-ispropertywritable)] => [CanReturnMultipleSuccessValues,Documentation(https://learn.microsoft.com/windows/win32/api/propsys/nf-propsys-ipropertystorecapabilities-ispropertywritable)]


### PR DESCRIPTION
Fixes: #1941

Adds `CanReturnMultipleSuccessValues` to `IPropertyStoreCapabilities::IsPropertyWritable` method. This method can return either `S_OK` or `S_FALSE`. Also removes the optional Attribute suffix on a few entries as cleanup.