### PR TITLE
Disable submodules where not needed and add pipeline message for PR builds

### DIFF
--- a/AzurePipelinesTemplates/win32docs-onebranch.yml
+++ b/AzurePipelinesTemplates/win32docs-onebranch.yml
@@ -28,6 +28,7 @@ stages:
     - template: win32metadata-checkout.yml
       parameters:
         RepoDirectory: ${{ parameters.RepoDirectory }}
+        Submodules: true
     - task: UseDotNet@2
       displayName: ⚙ Install .NET SDK
       inputs:

--- a/AzurePipelinesTemplates/win32docs-onebranch.yml
+++ b/AzurePipelinesTemplates/win32docs-onebranch.yml
@@ -1,7 +1,4 @@
 parameters:
-- name: "PipelineType"
-  type: string
-  default: "PullRequest"
 - name: "RepoDirectory"
   type: string
   default: "s"

--- a/AzurePipelinesTemplates/win32metadata-checkout.yml
+++ b/AzurePipelinesTemplates/win32metadata-checkout.yml
@@ -2,6 +2,9 @@ parameters:
 - name: "RepoDirectory"
   type: string
   default: "win32metadata"
+- name: "Submodules"
+  type: boolean
+  default: false
 
 steps:
 - script: git config --global core.longpaths true
@@ -9,4 +12,7 @@ steps:
   path: s/${{ parameters.RepoDirectory }}
   lfs: false
   displayName: Checkout win32metadata from github
-  submodules: recursive
+  ${{ if parameters.Submodules }}:
+    submodules: recursive
+  ${{ if not(parameters.Submodules) }}:
+    submodules: false

--- a/AzurePipelinesTemplates/win32metadata-onebranch.yml
+++ b/AzurePipelinesTemplates/win32metadata-onebranch.yml
@@ -78,7 +78,7 @@ stages:
         inputs:
           system: 'Custom'
           customVersion: '$(Version)'
-          
+
     # Add the PR Branch to the build version for clarity if this is a PR build
     # The Pipeline Version is used as part of the Github release in the Offical builds,
     # so we don't set it in Offical pipeline runs
@@ -87,7 +87,7 @@ stages:
         condition: eq(variables.arch, 'x64')
         inputs:
           system: 'Custom'
-          customVersion: '$(GitBuildVersionSimple) • ${{ parameters.OfficialBuild }}'
+          customVersion: '$(GitBuildVersionSimple) • ${{ parameters.PRBranch }}'
 
     - task: PowerShell@2
       displayName: GenerateMetadataSource.ps1

--- a/AzurePipelinesTemplates/win32metadata-onebranch.yml
+++ b/AzurePipelinesTemplates/win32metadata-onebranch.yml
@@ -66,6 +66,7 @@ stages:
         script: |
           $jsonString = nbgv get-version -f json
           $nbgvData = $jsonString | ConvertFrom-Json
+          Write-Host $jsonString
           $commitId = $nbgvData.GitCommitId
           $version = $nbgvData.CloudBuildNumber
           Write-Host "##vso[task.setvariable variable=CommitId;]$commitId"

--- a/AzurePipelinesTemplates/win32metadata-onebranch.yml
+++ b/AzurePipelinesTemplates/win32metadata-onebranch.yml
@@ -73,7 +73,7 @@ stages:
           Write-Host "##vso[task.setvariable variable=Version;]$version"
 
           $commitMessage = git log --format=%B -n 1 $commitId
-          $pipeline_message = ${{ parameters.PRBranch }} + ' • ' + $commitMessage
+          $pipeline_message = '${{ parameters.PRBranch }}' + ' • ' + $commitMessage
           $pipeline_message = $pipeline_message -replace '["/:<>\\|?@*]','_'
           if ($pipeline_message.Length -gt 200) {
               $pipeline_message = $pipeline_message.Substring(0, 200) + '...'

--- a/AzurePipelinesTemplates/win32metadata-onebranch.yml
+++ b/AzurePipelinesTemplates/win32metadata-onebranch.yml
@@ -1,13 +1,14 @@
 parameters:
-- name: "PipelineType"
-  type: string
-  default: "PullRequest"
 - name: "RepoDirectory"
   type: string
   default: "s" # Shortened repo directory name to keep paths under 260 characters. OneBranch issue where longpath setting doesn't get pushed down to submodules. 
 - name: OfficialBuild
   type: boolean
   default: false
+- name: 'PRBranch' # Used to name pipeline runs for PR builds
+  displayName: 'PR branch'
+  type: string
+  default: ''
 
 stages:
 - stage: scrape
@@ -75,19 +76,29 @@ stages:
         targetType: inline
         workingDirectory: ${{parameters.RepoDirectory}}
         script: |
-          Write-Host GitBuildVersion: $(GitBuildVersion)
-          Write-Host GitBuildVersionSimple: $(GitBuildVersionSimple)
-          Write-Host GitSimpleVersion: $(GitSimpleVersion)
-          Write-Host GitPrereleaseVersion: $(GitPrereleaseVersion)
-          Write-Host GitPrereleaseVersionNoLeadingHypher: $(GitPrereleaseVersionNoLeadingHypher)
-          Write-Host GitVersion: $(GitVersion)
+          Write-Host "GitBuildVersion: $(GitBuildVersion)"
+          Write-Host "GitBuildVersionSimple: $(GitBuildVersionSimple)"
+          Write-Host "GitSimpleVersion: $(GitSimpleVersion)"
+          Write-Host "GitPrereleaseVersion: $(GitPrereleaseVersion)"
+          Write-Host "GitPrereleaseVersionNoLeadingHypher: $(GitPrereleaseVersionNoLeadingHypher)"
+          Write-Host "GitVersion: $(GitVersion)"
 
     # Set the pipeline build number
-    - task: onebranch.pipeline.version@1
-      condition: eq(variables.arch, 'x64')
-      inputs:
-        system: 'Custom'
-        customVersion: '$(GitBuildVersionSimple)'
+    - ${{ if eq(parameters.PRBuilds, '') }}
+      - task: onebranch.pipeline.version@1
+        condition: eq(variables.arch, 'x64')
+        inputs:
+          system: 'Custom'
+          customVersion: '$(GitBuildVersionSimple)'
+    # Add the PR Branch to the build version for clarity if this is a PR build
+    # The Pipeline Version is used as part of the Github release in the Offical builds,
+    # so we don't set it in Offical pipeline runs
+    - ${{ if ne(parameters.PRBuilds, '') }}
+      - task: onebranch.pipeline.version@1
+        condition: eq(variables.arch, 'x64')
+        inputs:
+          system: 'Custom'
+          customVersion: '$(GitBuildVersionSimple) • ${{ parameters.OfficialBuild }}'
 
     - task: PowerShell@2
       displayName: GenerateMetadataSource.ps1

--- a/AzurePipelinesTemplates/win32metadata-onebranch.yml
+++ b/AzurePipelinesTemplates/win32metadata-onebranch.yml
@@ -21,8 +21,10 @@ stages:
           generateMetadataArgs: '-scrapeConstants'
         x64:
           arch: 'x64'
+          generateMetadataArgs: ''
         arm64:
           arch: 'arm64'
+          generateMetadataArgs: ''
     displayName: "Scrape headers"
     timeoutInMinutes: 60
     variables:
@@ -65,6 +67,20 @@ stages:
           $nbgvData = $jsonString | ConvertFrom-Json
           $commitId = $nbgvData.GitCommitId
           Write-Host "##vso[task.setvariable variable=CommitId;]$commitId"
+
+    - task: PowerShell@2
+      displayName: Print some variables
+      condition: eq(variables.arch, 'x64') # Only needed for x64
+      inputs:
+        targetType: inline
+        workingDirectory: ${{parameters.RepoDirectory}}
+        script: |
+          Write-Host GitBuildVersion: $(GitBuildVersion)
+          Write-Host GitBuildVersionSimple: $(GitBuildVersionSimple)
+          Write-Host GitSimpleVersion: $(GitSimpleVersion)
+          Write-Host GitPrereleaseVersion: $(GitPrereleaseVersion)
+          Write-Host GitPrereleaseVersionNoLeadingHypher: $(GitPrereleaseVersionNoLeadingHypher)
+          Write-Host GitVersion: $(GitVersion)
 
     # Set the pipeline build number
     - task: onebranch.pipeline.version@1

--- a/AzurePipelinesTemplates/win32metadata-onebranch.yml
+++ b/AzurePipelinesTemplates/win32metadata-onebranch.yml
@@ -68,20 +68,7 @@ stages:
           $nbgvData = $jsonString | ConvertFrom-Json
           $commitId = $nbgvData.GitCommitId
           Write-Host "##vso[task.setvariable variable=CommitId;]$commitId"
-
-    - task: PowerShell@2
-      displayName: Print some variables
-      condition: eq(variables.arch, 'x64') # Only needed for x64
-      inputs:
-        targetType: inline
-        workingDirectory: ${{parameters.RepoDirectory}}
-        script: |
-          Write-Host "GitBuildVersion: $env:GitBuildVersion"
-          Write-Host "GitBuildVersionSimple: $env:GitBuildVersionSimple"
-          Write-Host "GitSimpleVersion: $env:GitSimpleVersion"
-          Write-Host "GitPrereleaseVersion: $env:GitPrereleaseVersion"
-          Write-Host "GitPrereleaseVersionNoLeadingHypher: $env:GitPrereleaseVersionNoLeadingHypher"
-          Write-Host "GitVersion: $env:GitVersion"
+          Write-Host $jsonString
 
     # Set the pipeline build number
     - ${{ if eq(parameters.PRBranch, '') }}:

--- a/AzurePipelinesTemplates/win32metadata-onebranch.yml
+++ b/AzurePipelinesTemplates/win32metadata-onebranch.yml
@@ -67,8 +67,9 @@ stages:
           $jsonString = nbgv get-version -f json
           $nbgvData = $jsonString | ConvertFrom-Json
           $commitId = $nbgvData.GitCommitId
+          $version = $nbgvData.CloudBuildNumber
           Write-Host "##vso[task.setvariable variable=CommitId;]$commitId"
-          Write-Host $jsonString
+          Write-Host "##vso[task.setvariable variable=Version;]$version"
 
     # Set the pipeline build number
     - ${{ if eq(parameters.PRBranch, '') }}:
@@ -76,7 +77,8 @@ stages:
         condition: eq(variables.arch, 'x64')
         inputs:
           system: 'Custom'
-          customVersion: '$(GitBuildVersionSimple)'
+          customVersion: '$(Version)'
+          
     # Add the PR Branch to the build version for clarity if this is a PR build
     # The Pipeline Version is used as part of the Github release in the Offical builds,
     # so we don't set it in Offical pipeline runs

--- a/AzurePipelinesTemplates/win32metadata-onebranch.yml
+++ b/AzurePipelinesTemplates/win32metadata-onebranch.yml
@@ -68,8 +68,9 @@ stages:
           $nbgvData = $jsonString | ConvertFrom-Json
           Write-Host $jsonString
           $commitId = $nbgvData.GitCommitId
+          $version = $nbgvData.CloudBuildNumber
           Write-Host "##vso[task.setvariable variable=CommitId;]$commitId"
-          Write-Host "##vso[task.setvariable variable=Version;]$nbgvData.CloudBuildNumber"
+          Write-Host "##vso[task.setvariable variable=Version;]$version"
 
           $commitMessage = git log --format=%B -n 1 $commitId
           $pipeline_message = '${{ parameters.PRBranch }}' + ' • ' + $commitMessage
@@ -78,6 +79,10 @@ stages:
               $pipeline_message = $pipeline_message.Substring(0, 200) + '...'
           }
           Write-Host "##vso[task.setvariable variable=PipelineMessage;]$pipeline_message"
+
+          Write-Host "Setting Version to $version"
+          Write-Host "Setting CommitId to $commitId"
+          Write-Host "Setting PipelineMessage to $pipeline_message"
 
     # Set the pipeline build number
     - ${{ if eq(parameters.PRBranch, '') }}:

--- a/AzurePipelinesTemplates/win32metadata-onebranch.yml
+++ b/AzurePipelinesTemplates/win32metadata-onebranch.yml
@@ -68,9 +68,8 @@ stages:
           $nbgvData = $jsonString | ConvertFrom-Json
           Write-Host $jsonString
           $commitId = $nbgvData.GitCommitId
-          $version = $nbgvData.CloudBuildNumber
           Write-Host "##vso[task.setvariable variable=CommitId;]$commitId"
-          Write-Host "##vso[task.setvariable variable=Version;]$version"
+          Write-Host "##vso[task.setvariable variable=Version;]$nbgvData.CloudBuildNumber"
 
           $commitMessage = git log --format=%B -n 1 $commitId
           $pipeline_message = '${{ parameters.PRBranch }}' + ' • ' + $commitMessage
@@ -96,7 +95,7 @@ stages:
         condition: eq(variables.arch, 'x64')
         inputs:
           system: 'Custom'
-          customVersion: '$(GitBuildVersionSimple) • $(PipelineMessage)'
+          customVersion: '$(Version) • $(PipelineMessage)'
 
     - task: PowerShell@2
       displayName: GenerateMetadataSource.ps1

--- a/AzurePipelinesTemplates/win32metadata-onebranch.yml
+++ b/AzurePipelinesTemplates/win32metadata-onebranch.yml
@@ -72,6 +72,14 @@ stages:
           Write-Host "##vso[task.setvariable variable=CommitId;]$commitId"
           Write-Host "##vso[task.setvariable variable=Version;]$version"
 
+          $commitMessage = git log --format=%B -n 1 $commitId
+          $pipeline_message = ${{ parameters.PRBranch }} + ' • ' + $commitMessage
+          $pipeline_message = $pipeline_message -replace '["/:<>\\|?@*]','_'
+          if ($pipeline_message.Length -gt 200) {
+              $pipeline_message = $pipeline_message.Substring(0, 200) + '...'
+          }
+          Write-Host "##vso[task.setvariable variable=PipelineMessage;]$pipeline_message"
+
     # Set the pipeline build number
     - ${{ if eq(parameters.PRBranch, '') }}:
       - task: onebranch.pipeline.version@1
@@ -88,7 +96,7 @@ stages:
         condition: eq(variables.arch, 'x64')
         inputs:
           system: 'Custom'
-          customVersion: '$(GitBuildVersionSimple) • ${{ parameters.PRBranch }}'
+          customVersion: '$(GitBuildVersionSimple) • $(PipelineMessage)'
 
     - task: PowerShell@2
       displayName: GenerateMetadataSource.ps1

--- a/AzurePipelinesTemplates/win32metadata-onebranch.yml
+++ b/AzurePipelinesTemplates/win32metadata-onebranch.yml
@@ -84,7 +84,7 @@ stages:
           Write-Host "GitVersion: $(GitVersion)"
 
     # Set the pipeline build number
-    - ${{ if eq(parameters.PRBuilds, '') }}
+    - ${{ if eq(parameters.PRBuilds, '') }}:
       - task: onebranch.pipeline.version@1
         condition: eq(variables.arch, 'x64')
         inputs:
@@ -93,7 +93,7 @@ stages:
     # Add the PR Branch to the build version for clarity if this is a PR build
     # The Pipeline Version is used as part of the Github release in the Offical builds,
     # so we don't set it in Offical pipeline runs
-    - ${{ if ne(parameters.PRBuilds, '') }}
+    - ${{ if ne(parameters.PRBuilds, '') }}:
       - task: onebranch.pipeline.version@1
         condition: eq(variables.arch, 'x64')
         inputs:

--- a/AzurePipelinesTemplates/win32metadata-onebranch.yml
+++ b/AzurePipelinesTemplates/win32metadata-onebranch.yml
@@ -84,7 +84,7 @@ stages:
           Write-Host "GitVersion: $(GitVersion)"
 
     # Set the pipeline build number
-    - ${{ if eq(parameters.PRBuilds, '') }}:
+    - ${{ if eq(parameters.PRBranch, '') }}:
       - task: onebranch.pipeline.version@1
         condition: eq(variables.arch, 'x64')
         inputs:
@@ -93,7 +93,7 @@ stages:
     # Add the PR Branch to the build version for clarity if this is a PR build
     # The Pipeline Version is used as part of the Github release in the Offical builds,
     # so we don't set it in Offical pipeline runs
-    - ${{ if ne(parameters.PRBuilds, '') }}:
+    - ${{ if ne(parameters.PRBranch, '') }}:
       - task: onebranch.pipeline.version@1
         condition: eq(variables.arch, 'x64')
         inputs:

--- a/AzurePipelinesTemplates/win32metadata-onebranch.yml
+++ b/AzurePipelinesTemplates/win32metadata-onebranch.yml
@@ -76,12 +76,12 @@ stages:
         targetType: inline
         workingDirectory: ${{parameters.RepoDirectory}}
         script: |
-          Write-Host "GitBuildVersion: $(GitBuildVersion)"
-          Write-Host "GitBuildVersionSimple: $(GitBuildVersionSimple)"
-          Write-Host "GitSimpleVersion: $(GitSimpleVersion)"
-          Write-Host "GitPrereleaseVersion: $(GitPrereleaseVersion)"
-          Write-Host "GitPrereleaseVersionNoLeadingHypher: $(GitPrereleaseVersionNoLeadingHypher)"
-          Write-Host "GitVersion: $(GitVersion)"
+          Write-Host "GitBuildVersion: $env:GitBuildVersion"
+          Write-Host "GitBuildVersionSimple: $env:GitBuildVersionSimple"
+          Write-Host "GitSimpleVersion: $env:GitSimpleVersion"
+          Write-Host "GitPrereleaseVersion: $env:GitPrereleaseVersion"
+          Write-Host "GitPrereleaseVersionNoLeadingHypher: $env:GitPrereleaseVersionNoLeadingHypher"
+          Write-Host "GitVersion: $env:GitVersion"
 
     # Set the pipeline build number
     - ${{ if eq(parameters.PRBranch, '') }}:


### PR DESCRIPTION
- Disable submodule checkout for non-doc builds to speed up pipeline runs
- Fix the Pipeline Version to include the '-preview' for preview builds by using nbgv's CloudBuildNumber instead GitBuildVersionSimple
- Add a message to the Pipeline Version for PR builds to include the branch name and commit message.
  - There are restrictions on how long and what characters can be part of the "Pipeline Version", but this is a big improvement over just having a major.minor.patch number set. ADO normally allows for both a Version and a Message, but setting the Message after the pipeline is initialized (which is our use case since this github repo is only an ADO resource) isn't supported yet, so we insert this information into the Pipeline Version. 
  - The Pipeline Version is re-used in the Official pipeline runs as part of the github release, so we don't tamper with the Version string in that case.