### PR TITLE
Fix error where pipeline name ending in a '.' would cause the PR pipeline to fail

### DIFF
--- a/AzurePipelinesTemplates/win32metadata-onebranch.yml
+++ b/AzurePipelinesTemplates/win32metadata-onebranch.yml
@@ -78,7 +78,7 @@ stages:
           $pipeline_message = $pipeline_message -replace '["/:<>\\|?@*]','_'
           $pipeline_message = $pipeline_message.trim()
           # Pipeline versions cannot end in a '.'
-          if ($pipeline_message[$pipeline_message.length-1] == '.') {
+          if ($pipeline_message[$pipeline_message.length-1] -eq '.') {
               $pipeline_message = $pipeline_message + '0'
           }
           if ($pipeline_message.Length -gt 200) {

--- a/AzurePipelinesTemplates/win32metadata-onebranch.yml
+++ b/AzurePipelinesTemplates/win32metadata-onebranch.yml
@@ -78,7 +78,7 @@ stages:
           $pipeline_message = $pipeline_message -replace '["/:<>\\|?@*]','_'
           $pipeline_message = $pipeline_message.trim()
           # Pipeline versions cannot end in a '.'
-          if $pipeline_message[$pipeline_message.length-1] == '.' {
+          if ($pipeline_message[$pipeline_message.length-1] == '.') {
               $pipeline_message = $pipeline_message + '0'
           }
           if $pipeline_message[$pipeline]

--- a/AzurePipelinesTemplates/win32metadata-onebranch.yml
+++ b/AzurePipelinesTemplates/win32metadata-onebranch.yml
@@ -72,11 +72,18 @@ stages:
           Write-Host "##vso[task.setvariable variable=CommitId;]$commitId"
           Write-Host "##vso[task.setvariable variable=Version;]$version"
 
+          # Add the branch name and commit message to PR Pipeline build names 
           $commitMessage = git log --format=%B -n 1 $commitId
           $pipeline_message = '${{ parameters.PRBranch }}' + ' • ' + $commitMessage
           $pipeline_message = $pipeline_message -replace '["/:<>\\|?@*]','_'
+          $pipeline_message = $pipeline_message.trim()
+          # Pipeline versions cannot end in a '.'
+          if $pipeline_message[$pipeline_message.length-1] == '.' {
+              $pipeline_message = $pipeline_message + '0'
+          }
+          if $pipeline_message[$pipeline]
           if ($pipeline_message.Length -gt 200) {
-              $pipeline_message = $pipeline_message.Substring(0, 200) + '...'
+              $pipeline_message = $pipeline_message.Substring(0, 200) + '...(cont)'
           }
           Write-Host "##vso[task.setvariable variable=PipelineMessage;]$pipeline_message"
 

--- a/AzurePipelinesTemplates/win32metadata-onebranch.yml
+++ b/AzurePipelinesTemplates/win32metadata-onebranch.yml
@@ -81,7 +81,6 @@ stages:
           if ($pipeline_message[$pipeline_message.length-1] == '.') {
               $pipeline_message = $pipeline_message + '0'
           }
-          if $pipeline_message[$pipeline]
           if ($pipeline_message.Length -gt 200) {
               $pipeline_message = $pipeline_message.Substring(0, 200) + '...(cont)'
           }


### PR DESCRIPTION
Pipeline Versions are not allowed to end in a '.'

We are using the "Pipeline Version" in PR runs to simulate setting the pipeline name/message to diplay the branch name and commit message. ADO doesn't allow setting the Pipeline Name after the pipeline starts, and because the bulk of the source code sits in a "resource repository" (this win32metadata github repo) which isn't available until after the pipeline starts, we are using the Pipeline Version instead. This is a bit of a hack and hopefully ADO will support setting the Pipeline Name post-start soon. For now, this dramatically improves clarity when reading through the PR pipeline runs.