### PR TITLE
Correct PMPRADMINCONNECTIONHANGUPNOTIFICATION3 parameter 4

### DIFF
--- a/generation/WinSDK/emitter.settings.rsp
+++ b/generation/WinSDK/emitter.settings.rsp
@@ -1869,3 +1869,4 @@ IPropertyStoreCapabilities::IsPropertyWritable=[CanReturnMultipleSuccessValues]
 MFCreateAttributes::ppMFAttributes=[ComOutPtr]
 StartServiceCtrlDispatcherA::lpServiceStartTable=[NativeArrayInfo]
 StartServiceCtrlDispatcherW::lpServiceStartTable=[NativeArrayInfo]
+PMPRADMINCONNECTIONHANGUPNOTIFICATION3::param3=RAS_CONNECTION_3*

--- a/scripts/ChangesSinceLastRelease.txt
+++ b/scripts/ChangesSinceLastRelease.txt
@@ -26,3 +26,6 @@ Windows.Win32.NetworkManagement.Ndis.Apis.NET_IF_COMPARTMENT_ID_PRIMARY added
 Windows.Win32.NetworkManagement.Ndis.Apis.NET_IF_COMPARTMENT_ID_UNSPECIFIED added
 # Add QueryOptionalDelayLoadedAPI
 Windows.Win32.System.LibraryLoader.Apis.QueryOptionalDelayLoadedAPI added
+# Correct PMPRADMINCONNECTIONHANGUPNOTIFICATION3 parameter 4
+Windows.Win32.NetworkManagement.Rras.PMPRADMINCONNECTIONHANGUPNOTIFICATION3.Invoke : param3 : [In] => [In,Out]
+Windows.Win32.NetworkManagement.Rras.PMPRADMINCONNECTIONHANGUPNOTIFICATION3.Invoke : param3...RAS_CONNECTION_3 => RAS_CONNECTION_3*


### PR DESCRIPTION
Partially fixes #1961.

Adjusts PMPRADMINCONNECTIONHANGUPNOTIFICATION3 parameter 4 to align with docs. Appears to be a SDK bug (mprapi.h, 26100).