### PR TITLE
Remove StructSizeField from BLOB, BSTRBLOB

### DIFF
--- a/generation/WinSDK/emitter.settings.rsp
+++ b/generation/WinSDK/emitter.settings.rsp
@@ -1871,3 +1871,5 @@ StartServiceCtrlDispatcherA::lpServiceStartTable=[NativeArrayInfo]
 StartServiceCtrlDispatcherW::lpServiceStartTable=[NativeArrayInfo]
 PMPRADMINCONNECTIONHANGUPNOTIFICATION3::param3=RAS_CONNECTION_3*
 DEVPROPKEY=[AlsoUsableFor("PROPERTYKEY")]
+BLOB=[-StructSizeField]
+BSTRBLOB=[-StructSizeField]

--- a/scripts/ChangesSinceLastRelease.txt
+++ b/scripts/ChangesSinceLastRelease.txt
@@ -2589,3 +2589,6 @@ Windows.Win32.System.Ioctl.Apis.DEVPKEY_Storage_Portable...Windows.Win32.Devices
 Windows.Win32.System.Ioctl.Apis.DEVPKEY_Storage_Removable_Media...Windows.Win32.Devices.Properties.DEVPROPKEY => Windows.Win32.Foundation.DEVPROPKEY
 Windows.Win32.System.Ioctl.Apis.DEVPKEY_Storage_System_Critical...Windows.Win32.Devices.Properties.DEVPROPKEY => Windows.Win32.Foundation.DEVPROPKEY
 Windows.Win32.System.Power.Apis.PROCESSOR_NUMBER_PKEY...Windows.Win32.Devices.Properties.DEVPROPKEY => Windows.Win32.Foundation.DEVPROPKEY
+# Remove StructSizeField from BLOB, BSTRBLOB
+Windows.Win32.System.Com.BLOB : [Documentation(https://learn.microsoft.com/windows/win32/api/nspapi/ns-nspapi-blob),StructSizeField(cbSize)] => [Documentation(https://learn.microsoft.com/windows/win32/api/nspapi/ns-nspapi-blob)]
+Windows.Win32.System.Com.StructuredStorage.BSTRBLOB : [StructSizeField(cbSize)] => 

--- a/sources/ClangSharpSourceToWinmd/MetadataSyntaxTreeCleaner.cs
+++ b/sources/ClangSharpSourceToWinmd/MetadataSyntaxTreeCleaner.cs
@@ -219,21 +219,6 @@ namespace ClangSharpSourceToWinmd
                     node = node.AddAttributeLists(attributeList);
                 }
 
-                if (this.GetRemapInfo(fullName, node.AttributeLists, out var listAttributes, null, out _, out string newName))
-                {
-                    node = (StructDeclarationSyntax)base.VisitStructDeclaration(node);
-                    node = node.WithAttributeLists(FixRemappedAttributes(node.AttributeLists, listAttributes));
-
-                    if (newName != null)
-                    {
-                        node = node.WithIdentifier(SyntaxFactory.Identifier(newName));
-                    }
-                }
-                else
-                {
-                    node = (StructDeclarationSyntax)base.VisitStructDeclaration(node);
-                }
-
                 foreach (var member in node.Members)
                 {
                     if (!(member is FieldDeclarationSyntax))
@@ -252,6 +237,21 @@ namespace ClangSharpSourceToWinmd
 
                         node = node.AddAttributeLists(attributeList);
                     }
+                }
+
+                if (this.GetRemapInfo(fullName, node.AttributeLists, out var listAttributes, null, out _, out string newName))
+                {
+                    node = (StructDeclarationSyntax)base.VisitStructDeclaration(node);
+                    node = node.WithAttributeLists(FixRemappedAttributes(node.AttributeLists, listAttributes));
+
+                    if (newName != null)
+                    {
+                        node = node.WithIdentifier(SyntaxFactory.Identifier(newName));
+                    }
+                }
+                else
+                {
+                    node = (StructDeclarationSyntax)base.VisitStructDeclaration(node);
                 }
 
                 return node;


### PR DESCRIPTION
Related: #1961

Removed `StructSizeField` from `BLOB` and `BSTRBLOB` as these were mistakenly flagged due to the `cbSize` fields. The logic that adds this attribute has also been moved up to allow proper remapping/removal of this attribute.