### PR TITLE
Remove RAIIFree attribute from PSID

### DIFF
--- a/generation/WinSDK/autoTypes.json
+++ b/generation/WinSDK/autoTypes.json
@@ -82,7 +82,6 @@
   {
     "Namespace": "Windows.Win32.Security",
     "Name": "PSID",
-    "CloseApi": "FreeSid",
     "ValueType": "void*",
     "NativeTypedef": true
   },

--- a/scripts/ChangesSinceLastRelease.txt
+++ b/scripts/ChangesSinceLastRelease.txt
@@ -2592,3 +2592,5 @@ Windows.Win32.System.Power.Apis.PROCESSOR_NUMBER_PKEY...Windows.Win32.Devices.Pr
 # Remove StructSizeField from BLOB, BSTRBLOB
 Windows.Win32.System.Com.BLOB : [Documentation(https://learn.microsoft.com/windows/win32/api/nspapi/ns-nspapi-blob),StructSizeField(cbSize)] => [Documentation(https://learn.microsoft.com/windows/win32/api/nspapi/ns-nspapi-blob)]
 Windows.Win32.System.Com.StructuredStorage.BSTRBLOB : [StructSizeField(cbSize)] => 
+# Remove RAIIFree attribute from PSID
+Windows.Win32.Security.PSID : [NativeTypedef,RAIIFree(FreeSid)] => [NativeTypedef]


### PR DESCRIPTION
Fixes: #1985, fixes: #1986

Removing RAIIFree attribute from PSID due to ambiguous freeing semantics for PSID. See AllocateAndInitializeSid vs ConvertStringSidToSid.