### PR TITLE
Add NativeAnnotationAttribute to the metadata file

### DIFF
--- a/generation/WinSDK/manual/Metadata.cs
+++ b/generation/WinSDK/manual/Metadata.cs
@@ -157,6 +157,14 @@ public class MetadataTypedefAttribute : Attribute
     }
 }
 
+[AttributeUsage(AttributeTargets.Struct | AttributeTargets.Enum | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.ReturnValue, AllowMultiple = true, Inherited = false)]
+public class NativeAnnotationAttribute : Attribute
+{
+    public NativeAnnotationAttribute(string annotation)
+    {
+    }
+}
+
 public class NativeArrayInfoAttribute : Attribute
 {
     //


### PR DESCRIPTION
ClangSharp has recently started emitting the `NativeAnnotation` attribute for C++ `annotate` attributes: <https://github.com/dotnet/ClangSharp/pull/552>

This PR adds the definition of `NativeAnnotationAttribute` to the metadata.cs.