### PR TITLE
Address dependabot alerts about MessagePack NuGet package

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+registries:
+  nuget-azure-devops:
+    type: nuget-feed
+    # The URL of the NuGet feed to check for updates
+    url: https://pkgs.dev.azure.com/shine-oss/Win32Metadata/_packaging/Win32Metadata-Dependencies/nuget/v3/index.json
+updates:
+  # Enable version updates for nuget
+  - package-ecosystem: "nuget"
+    # Look for NuGet dependency info from the `root` directory
+    directory: "/"
+    # Check the nuget registry for updates monthly
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 10
+    commit-message:
+      # Prefix all commit messages with "dependbot-security-updates: "
+      prefix: "dependbot-security-updates"
+    registries:
+      - nuget-azure-devops
+    groups:
+      nuget-dependencies:
+        dependency-type: production
+        applies-to: security-updates

--- a/apidocs/Microsoft.Windows.SDK.Win32Docs/Microsoft.Windows.SDK.Win32Docs.csproj
+++ b/apidocs/Microsoft.Windows.SDK.Win32Docs/Microsoft.Windows.SDK.Win32Docs.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MessagePack" Version="2.2.85" />
+    <PackageReference Include="MessagePack" Version="2.5.187" />
   </ItemGroup>
 
   <ItemGroup>

--- a/apidocs/ScrapeDocs/ScrapeDocs.csproj
+++ b/apidocs/ScrapeDocs/ScrapeDocs.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MessagePack" Version="2.2.85" />
+    <PackageReference Include="MessagePack" Version="2.5.187" />
     <PackageReference Include="YamlDotNet" Version="11.1.1" />
   </ItemGroup>
 


### PR DESCRIPTION
**Issue:**
Dependabot [found ](https://github.com/microsoft/win32metadata/security/dependabot/6) 1 NuGet package that requires updating to address security vulnerabilities.

**Fix:**
Update MessagePack to latest stable release to address security vulnerabilities.
Also add a [dependabot.yml](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates) to override the default behavior and ensure proper NuGet feed URL.

**How verified:**
Built both projects in Visual Studio to confirm projects built with no issues.