### PR TITLE
Update Install-DotNetTool.ps1 to use repos NuGet.config

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -228,6 +228,8 @@ Run a [full build](#full-builds), fix any metadata issues that surface, then upd
 
 To update the ClangSharp dependency, modify the version number in [ScrapeHeaders.cs](https://github.com/microsoft/win32metadata/blob/fca56d40752c1e8beee7c616e89f06c409fe09b7/sources/GeneratorSdk/MetadataTasks/ScrapeHeaders.cs#L15).
 
+To override the default NuGet feed source for ClangSharp add a `<NuGetPackageSource>` PropertyItem to your proj file file with the URL of the NuGet feed source.
+
 Run a [full build](#full-builds), fix any metadata issues that surface, then update the baseline.
 
 ## Validating changes

--- a/generation/WinSDK/Windows.Win32.proj
+++ b/generation/WinSDK/Windows.Win32.proj
@@ -11,7 +11,7 @@
     <Win32MetadataAssetsDir>$(RepoRootPath)sources\GeneratorSdk\tools\assets</Win32MetadataAssetsDir>
     <Win32WinmdBinDir>$(RepoRootPath)bin</Win32WinmdBinDir>
     <TaskBinDir>$(LocalTaskBinDir)</TaskBinDir>
-    <NuGetConfigFile>$(RepoRootPath)nuget.config</NuGetConfigFile>
+    <NuGetPackageSource>https://pkgs.dev.azure.com/shine-oss/Win32Metadata/_packaging/Win32Metadata-Dependencies/nuget/v3/index.json</NuGetPackageSource>
   </PropertyGroup>
 
   <ItemGroup>

--- a/generation/WinSDK/Windows.Win32.proj
+++ b/generation/WinSDK/Windows.Win32.proj
@@ -11,6 +11,7 @@
     <Win32MetadataAssetsDir>$(RepoRootPath)sources\GeneratorSdk\tools\assets</Win32MetadataAssetsDir>
     <Win32WinmdBinDir>$(RepoRootPath)bin</Win32WinmdBinDir>
     <TaskBinDir>$(LocalTaskBinDir)</TaskBinDir>
+    <NuGetConfigFile>$(RepoRootPath)nuget.config</NuGetConfigFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/scripts/CommonUtils.ps1
+++ b/scripts/CommonUtils.ps1
@@ -67,7 +67,7 @@ function Install-BuildTools
 {
     Param([switch]$Clean)
 
-    & "$PSScriptRoot\Install-DotNetTool" -Name nbgv
+    & "$PSScriptRoot\Install-DotNetTool" -Name nbgv -NuGetConfigFile "$rootDir\nuget.Config"
 
     if ($Clean.IsPresent)
     {

--- a/scripts/Install-DotNetTool.ps1
+++ b/scripts/Install-DotNetTool.ps1
@@ -1,7 +1,11 @@
 Param ([string] $Name, [string] $Version = '', [string] $NuGetConfigFile)
 
-if (-not $NuGetConfigFile -or -not (Test-Path -Path $NuGetConfigFile -PathType Leaf)) {
-    throw "NuGetConfigFile is either null or not a valid file path."
+if (-not $NuGetConfigFile) {
+    throw "NuGetConfigFile is null. NuGetConfigFile must be a valid file path to a NuGet.config file."
+}
+
+if (-not (Test-Path -Path $NuGetConfigFile -PathType Leaf)) {
+	throw "NuGetConfigFile file wasn't found at supplied path. NuGetConfigFile must be a valid file path to a NuGet.config file."
 }
 
 if ($Version -ne '')

--- a/scripts/Install-DotNetTool.ps1
+++ b/scripts/Install-DotNetTool.ps1
@@ -1,11 +1,15 @@
-Param ([string] $Name, [string] $Version = '')
+Param ([string] $Name, [string] $Version = '', [string] $NuGetConfigFile)
+
+if (-not $NuGetConfigFile -or -not (Test-Path -Path $NuGetConfigFile -PathType Leaf)) {
+    throw "NuGetConfigFile is either null or not a valid file path."
+}
 
 if ($Version -ne '')
 {
     $installed = & dotnet tool list -g | select-string -Pattern "$Name\s+$Version"
     if ($installed -eq $null)
     {
-        & dotnet tool update --global $Name --version $Version
+        & dotnet tool update --global $Name --version $Version --configfile $NuGetConfigFile
     }
 }
 else
@@ -13,6 +17,6 @@ else
     $installed = & dotnet tool list -g | select-string -Pattern "$Name"
     if ($installed -eq $null)
     {
-        & dotnet tool update --global $Name
+        & dotnet tool update --global $Name --configfile $NuGetConfigFile
     }
 }

--- a/sources/GeneratorSdk/MetadataTasks/ScrapeHeaders.cs
+++ b/sources/GeneratorSdk/MetadataTasks/ScrapeHeaders.cs
@@ -193,8 +193,8 @@ namespace MetadataTasks
 
             try
             {
-                // try and delete the file
-                // File.Delete(nugetConfigFile);
+                // try and delete the file generated nuget.config file.
+                File.Delete(nugetConfigFile);
             }
             catch(Exception e)
             {

--- a/sources/GeneratorSdk/MetadataTasks/ScrapeHeaders.cs
+++ b/sources/GeneratorSdk/MetadataTasks/ScrapeHeaders.cs
@@ -72,6 +72,9 @@ namespace MetadataTasks
         [Required]
         public string ScriptsDir { get; set; }
 
+        [Required]
+        public string NuGetConfigFile { get; set; }
+
         public override bool Execute()
         {
 #if DEBUG
@@ -183,7 +186,7 @@ namespace MetadataTasks
         private bool EnsureClangSharpInstalled()
         {
             string scriptPath = Path.Combine(this.ScriptsDir, "Install-DotNetTool.ps1");
-            string scriptArgs = $"-Name ClangSharpPInvokeGenerator -Version {ClangSharpVersion}";
+            string scriptArgs = $"-Name ClangSharpPInvokeGenerator -Version {ClangSharpVersion} -NuGetConfigFile {this.NuGetConfigFile}";
             return TaskUtils.CallPowershellScript(scriptPath, scriptArgs, this.Log, out _);
         }
 

--- a/sources/GeneratorSdk/MetadataTasks/ScrapeHeaders.cs
+++ b/sources/GeneratorSdk/MetadataTasks/ScrapeHeaders.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Xml.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
@@ -73,7 +74,7 @@ namespace MetadataTasks
         public string ScriptsDir { get; set; }
 
         [Required]
-        public string NuGetConfigFile { get; set; }
+        public string NuGetPackageSource { get; set; }
 
         public override bool Execute()
         {
@@ -185,9 +186,21 @@ namespace MetadataTasks
 
         private bool EnsureClangSharpInstalled()
         {
+            string nugetConfigFile = this.GenerateNuGetConfig(this.NuGetPackageSource);
             string scriptPath = Path.Combine(this.ScriptsDir, "Install-DotNetTool.ps1");
-            string scriptArgs = $"-Name ClangSharpPInvokeGenerator -Version {ClangSharpVersion} -NuGetConfigFile {this.NuGetConfigFile}";
-            return TaskUtils.CallPowershellScript(scriptPath, scriptArgs, this.Log, out _);
+            string scriptArgs = $"-Name ClangSharpPInvokeGenerator -Version {ClangSharpVersion} -NuGetConfigFile {nugetConfigFile}";
+            bool installResult = TaskUtils.CallPowershellScript(scriptPath, scriptArgs, this.Log, out _);
+
+            try
+            {
+                // try and delete the file
+                // File.Delete(nugetConfigFile);
+            }
+            catch(Exception e)
+            {
+                this.Log.LogWarningFromException(e);
+            }
+            return installResult;
         }
 
         private bool AreNonPartitionFilesUpToDate()
@@ -488,6 +501,27 @@ $@"--file
             }
 
             return items;
+        }
+
+        private string GenerateNuGetConfig(string url)
+        {
+            var config = new XElement("configuration",
+                new XElement("packageSources",
+                    new XElement("clear"),
+                    new XElement("add",
+                        new XAttribute("key", "Win32Metadata-Dependencies"),
+                        new XAttribute("value", url),
+                        new XAttribute("protocolVersion", "3")
+                    )
+                ),
+                new XElement("disabledPackageSources",
+                    new XElement("clear")
+                )
+            );
+
+            string filePath = Path.Combine(this.ScriptsDir, "NuGet.config");
+            config.Save(filePath);
+            return filePath;
         }
     }
 }

--- a/sources/GeneratorSdk/MetadataTasks/TaskUtils.cs
+++ b/sources/GeneratorSdk/MetadataTasks/TaskUtils.cs
@@ -161,12 +161,6 @@ namespace MetadataTasks
             return true;
         }
 
-        public static bool EnsureClangSharpInstalled(string scriptsDir, TaskLoggingHelper log)
-        {
-            string scriptPath = Path.Combine(scriptsDir, "InstallTools.ps1");
-            return CallPowershellScript(scriptPath, string.Empty, log, out _);
-        }
-
         public static string GetVcDirPath(string scriptsDir, TaskLoggingHelper log)
         {
             string scriptPath = Path.Combine(scriptsDir, "GetVcDirPath.ps1");

--- a/sources/GeneratorSdk/samples/DiaSdk/Microsoft.Dia.Win32Metadata.nuspec
+++ b/sources/GeneratorSdk/samples/DiaSdk/Microsoft.Dia.Win32Metadata.nuspec
@@ -17,7 +17,7 @@
     <icon>images\windows.png</icon>
     <repository type="git" url="https://github.com/microsoft/win32metadata.git" />
     <dependencies>
-      <dependency id="Microsoft.Windows.SDK.Win32Metadata" version="63.0.22-preview-g1fc059f410" />
+      <dependency id="Microsoft.Windows.SDK.Win32Metadata" version="54.0.28-preview" />
     </dependencies>
   </metadata>
 

--- a/sources/GeneratorSdk/samples/DiaSdk/Microsoft.Dia.Win32Metadata.nuspec
+++ b/sources/GeneratorSdk/samples/DiaSdk/Microsoft.Dia.Win32Metadata.nuspec
@@ -17,7 +17,7 @@
     <icon>images\windows.png</icon>
     <repository type="git" url="https://github.com/microsoft/win32metadata.git" />
     <dependencies>
-      <dependency id="Microsoft.Windows.SDK.Win32Metadata" version="54.0.28-preview" />
+      <dependency id="Microsoft.Windows.SDK.Win32Metadata" version="63.0.22-preview-g1fc059f410" />
     </dependencies>
   </metadata>
 

--- a/sources/GeneratorSdk/samples/GeneratorSampleDebug/GeneratorSampleDebug.proj
+++ b/sources/GeneratorSdk/samples/GeneratorSampleDebug/GeneratorSampleDebug.proj
@@ -11,6 +11,7 @@
     <Win32MetadataScraperAssetsDir>$(Win32MetadataAssetsDir)\scraper</Win32MetadataScraperAssetsDir>
     <Win32WinmdBinDir>$(RepoRootPath)bin</Win32WinmdBinDir>
     <TaskBinDir>$(LocalTaskBinDir)</TaskBinDir>
+    <NuGetConfigFile>$(RepoRootPath)nuget.config</NuGetConfigFile>
   </PropertyGroup>
 
   <Import Project="..\..\sdk\sdk.props" />

--- a/sources/GeneratorSdk/samples/GeneratorSampleDebug/GeneratorSampleDebug.proj
+++ b/sources/GeneratorSdk/samples/GeneratorSampleDebug/GeneratorSampleDebug.proj
@@ -11,7 +11,7 @@
     <Win32MetadataScraperAssetsDir>$(Win32MetadataAssetsDir)\scraper</Win32MetadataScraperAssetsDir>
     <Win32WinmdBinDir>$(RepoRootPath)bin</Win32WinmdBinDir>
     <TaskBinDir>$(LocalTaskBinDir)</TaskBinDir>
-    <NuGetConfigFile>$(RepoRootPath)nuget.config</NuGetConfigFile>
+    <NuGetPackageSource>https://pkgs.dev.azure.com/shine-oss/Win32Metadata/_packaging/Win32Metadata-Dependencies/nuget/v3/index.json</NuGetPackageSource>
   </PropertyGroup>
 
   <Import Project="..\..\sdk\sdk.props" />

--- a/sources/GeneratorSdk/sdk/sdk.props
+++ b/sources/GeneratorSdk/sdk/sdk.props
@@ -29,7 +29,7 @@
     <ObjDir Condition="'$(ObjDir)' == ''">$(MSBuildProjectDirectory)\obj</ObjDir>
     <CompiledHeadersDir Condition="'$(CompiledHeadersDir)' == ''">$(ObjDir)\CompiledHeaders</CompiledHeadersDir>
     <SdkIncRoot>$(TargetPlatformSdkRootOverride)\include\$(TargetPlatformVersion)</SdkIncRoot>
-    <NuGetConfigFile Condition="'$(NuGetConfigFile)' == ''">$(Win32MetadataSdkRoot)\nuget.config</NuGetConfigFile>
+    <NuGetPackageSource Condition="'$(NuGetPackageSource)' == ''">https://pkgs.dev.azure.com/shine-oss/Win32Metadata/_packaging/Win32Metadata-Dependencies/nuget/v3/index.json</NuGetPackageSource>
 
     <Win32MetadataAssetsDir Condition="'$(Win32MetadataAssetsDir)' == ''">$(Win32MetadataSdkRoot)\tools\assets</Win32MetadataAssetsDir>
     <WinSDKAssets Condition="'$(WinSDKAssets)' == ''">$(Win32MetadataAssetsDir)\WinSDK</WinSDKAssets>

--- a/sources/GeneratorSdk/sdk/sdk.props
+++ b/sources/GeneratorSdk/sdk/sdk.props
@@ -29,6 +29,7 @@
     <ObjDir Condition="'$(ObjDir)' == ''">$(MSBuildProjectDirectory)\obj</ObjDir>
     <CompiledHeadersDir Condition="'$(CompiledHeadersDir)' == ''">$(ObjDir)\CompiledHeaders</CompiledHeadersDir>
     <SdkIncRoot>$(TargetPlatformSdkRootOverride)\include\$(TargetPlatformVersion)</SdkIncRoot>
+    <NuGetConfigFile Condition="'$(NuGetConfigFile)' == ''">$(Win32MetadataSdkRoot)\nuget.config</NuGetConfigFile>
 
     <Win32MetadataAssetsDir Condition="'$(Win32MetadataAssetsDir)' == ''">$(Win32MetadataSdkRoot)\tools\assets</Win32MetadataAssetsDir>
     <WinSDKAssets Condition="'$(WinSDKAssets)' == ''">$(Win32MetadataAssetsDir)\WinSDK</WinSDKAssets>

--- a/sources/GeneratorSdk/sdk/sdk.targets
+++ b/sources/GeneratorSdk/sdk/sdk.targets
@@ -211,7 +211,7 @@
       ExcludeFromCrossarch="$(ExcludeFromCrossarch)"
       MSBuildProjectDirectory="$(MSBuildProjectDirectory)"
       PartitionFilter="$(PartitionFilter)"
-      NuGetConfigFile="$(NuGetConfigFile)"/>
+      NuGetPackageSource="$(NuGetPackageSource)"/>
 
   </Target>
 

--- a/sources/GeneratorSdk/sdk/sdk.targets
+++ b/sources/GeneratorSdk/sdk/sdk.targets
@@ -210,7 +210,8 @@
       Win32MetadataScraperAssetsDir="$(Win32MetadataScraperAssetsDir)"
       ExcludeFromCrossarch="$(ExcludeFromCrossarch)"
       MSBuildProjectDirectory="$(MSBuildProjectDirectory)"
-      PartitionFilter="$(PartitionFilter)"/>
+      PartitionFilter="$(PartitionFilter)"
+      NuGetConfigFile="$(NuGetConfigFile)"/>
 
   </Target>
 


### PR DESCRIPTION
**Issue:**
NuGet.config was not being taking into account when running Install-DotNetTool.ps1.

**Fix:**
Pass NuGet.config into Install-DotNetTool.ps1. 

Since, Install-DotNetTool.ps1 now required a NuGet.config file winmdgenerator needed to be updated to supply a NuGet.config as Install-DotNetTool.ps1 is called to install [ClangSharpPInvokeGenerator](https://github.com/microsoft/win32metadata/blob/35d6cb24f7f9c2e6c16e1855384400744d2643eb/sources/GeneratorSdk/MetadataTasks/ScrapeHeaders.cs#L186). 

To allow for flexibility by consumers **NuGetPackageSource** build property was added to Code, Props and targets to enable overriding from the default package source. CONTRIBUTING.MD was also generated to mention the NuGetPackageSource override.

**How tested:**
1. Ran .\DoAll.ps1 -clean and confirmed successful output and test pass
2. Tested generated local package from of winmdgenerator in the wdkmetadata repo using .\DoAll.ps1 -clean and confirmed successful output and tests pass.