### PR TITLE
Apply same NuGetConfigFile change as wdkmetadata to pipeline yaml

### DIFF
--- a/AzurePipelinesTemplates/win32metadata-onebranch.yml
+++ b/AzurePipelinesTemplates/win32metadata-onebranch.yml
@@ -53,7 +53,7 @@ stages:
         targetType: inline
         workingDirectory: ${{parameters.RepoDirectory}}
         script: |
-          .\scripts\Install-DotNetTool.ps1 -Name nbgv
+          .\scripts\Install-DotNetTool.ps1 -Name nbgv -NuGetConfigFile '$(Build.SourcesDirectory)\${{parameters.RepoDirectory}}\nuget.config'
           nbgv cloud --common-vars
 
     # Generate the Azure Devops pipeline build number, since nbgv cannot do it for OneBranch pipelines


### PR DESCRIPTION
**Issue:**
#2013 broke official build pipeilnes

![image](https://github.com/user-attachments/assets/3bc56f05-6c37-41f6-a8b6-dcc4cd9a6fc2)

**Root Cause:**
-NuGetConfigFile wasn't passed into Install-DotNetTools.ps1 like in the wdkmetadata pipeline: https://github.com/microsoft/wdkmetadata/blob/599d7365376dcf70062dbfde11f91cb80b1e56bc/AzurePipelinesTemplates/wdkmetadata-onebranch.yml#L55

**Fix:**
Apply same NuGetConfigFile change as wdkmetadata to pipeline yaml.

**How verified:**
1. Ran PR build and confirmed success with fix.