### PR TITLE
nbgv still pulled from nuget.org

### DIFF
--- a/AzurePipelinesTemplates/win32docs-onebranch.yml
+++ b/AzurePipelinesTemplates/win32docs-onebranch.yml
@@ -38,7 +38,7 @@ stages:
       inputs:
         packageType: runtime
         version: 2.1.x
-    - powershell: dotnet tool update --global nbgv
+    - powershell: dotnet tool update --global nbgv --configfile  $(Build.SourcesDirectory)\${{parameters.RepoDirectory}}\nuget.config
       displayName: ⚙ Install nbgv
     - task: PowerShell@2
       displayName: 🏭 dotnet build

--- a/AzurePipelinesTemplates/win32metadata-onebranch.yml
+++ b/AzurePipelinesTemplates/win32metadata-onebranch.yml
@@ -126,6 +126,13 @@ stages:
         script: |
           Write-Host "Saving Source Commit ID for github release pipeline"
           "$(CommitId)" | Out-File $(Build.SourcesDirectory)\$(ob_outputDirectory)\SourceCommit.txt
+    
+    # Copy build logs from GenerateMetadataSource to artifact location that will automatically get picked up
+    - task: CopyFiles@2
+      displayName: 📢 Copy build logs to pipeline artifact directory 
+      inputs:
+        SourceFolder: '$(Build.SourcesDirectory)/${{parameters.RepoDirectory}}/bin/logs'
+        TargetFolder: '$(Build.SourcesDirectory)/$(ob_outputDirectory)/logs'
 
 - stage: build_winmd
   displayName: "Build WinMD"
@@ -242,12 +249,12 @@ stages:
         files_to_sign: '**/*.nupkg'
         search_root: $(OutputPackagesDir)
 
-    # Copy build logs to artifact staging directory
+    # Copy build logs from Build WinMD to artifact location that will automatically get picked up
     - task: CopyFiles@2
-      displayName: 📢 Copy build logs to pipeline artifact staging directory 
+      displayName: 📢 Copy build logs to pipeline artifact location 
       inputs:
         SourceFolder: '$(Build.SourcesDirectory)/${{parameters.RepoDirectory}}/bin/logs'
-        TargetFolder: '$(Build.ArtifactStagingDirectory)'
+        TargetFolder: '$(ob_outputDirectory)/logs'
 
     # Copy nuget package to artifact staging directory
     - task: CopyFiles@2

--- a/scripts/BuildMetadataBin.ps1
+++ b/scripts/BuildMetadataBin.ps1
@@ -50,5 +50,12 @@ else
     $configuration = "Release"
 }
 
-dotnet build "$windowsWin32ProjectRoot" -c $configuration -t:EmitWinmd -p:WinmdVersion=$assemblyVersion -p:OutputWinmd=$outputWinmdFileName -p:SkipScraping=$skipScraping "-bl:$PSScriptRoot\..\bin\logs\BuildMetadataBin.binlog"
+$rootDir = [System.IO.Path]::GetFullPath("$PSScriptRoot\..")
+
+# Explicitly restore the Win32Metadata project to avoid issues restore happening during build
+& dotnet restore "$windowsWin32ProjectRoot" --configfile "$rootDir\nuget.Config"
+
+$timestamp = Get-Date -Format "yyyyMMddHHmmss"
+$logFile = "$PSScriptRoot\..\bin\logs\BuildMetadataBin_$timestamp.binlog"
+& dotnet build "$windowsWin32ProjectRoot" -c $configuration -t:EmitWinmd -p:WinmdVersion=$assemblyVersion -p:OutputWinmd=$outputWinmdFileName -p:SkipScraping=$skipScraping "-bl:$logFile" --no-restore
 ThrowOnNativeProcessError

--- a/scripts/GenerateMetadataSource.ps1
+++ b/scripts/GenerateMetadataSource.ps1
@@ -26,7 +26,7 @@ else
 $rootDir = [System.IO.Path]::GetFullPath("$PSScriptRoot\..")
 
 # Explicitly restore the Win32Metadata project to avoid issues restore happening during build
-& dotnet restore "$wdkProjectRoot" --configfile "$rootDir\nuget.Config"
+& dotnet restore "$windowsWin32ProjectRoot" --configfile "$rootDir\nuget.Config"
 
 # Create a unique log file for the build
 $timestamp = Get-Date -Format "yyyyMMddHHmmss"

--- a/scripts/GenerateMetadataSource.ps1
+++ b/scripts/GenerateMetadataSource.ps1
@@ -23,5 +23,15 @@ else
     $target = "ScrapeHeaders"
 }
 
-dotnet build "$windowsWin32ProjectRoot" -c Release -p:ScanArch=$arch -t:$target "-bl:$PSScriptRoot\..\bin\logs\GenerateMetadataSources.binlog"
+$rootDir = [System.IO.Path]::GetFullPath("$PSScriptRoot\..")
+
+# Explicitly restore the Win32Metadata project to avoid issues restore happening during build
+& dotnet restore "$wdkProjectRoot" --configfile "$rootDir\nuget.Config"
+
+# Create a unique log file for the build
+$timestamp = Get-Date -Format "yyyyMMddHHmmss"
+$logFile = "$PSScriptRoot\..\bin\logs\GenerateMetadataSources_$timestamp.binlog"
+
+# Build the Win32Metadata Project
+& dotnet build "$windowsWin32ProjectRoot" -c Release -p:ScanArch=$arch -t:$target --no-restore "-bl:$logFile"
 ThrowOnNativeProcessError

--- a/scripts/Install-DotNetTool.ps1
+++ b/scripts/Install-DotNetTool.ps1
@@ -11,7 +11,7 @@ if (-not (Test-Path -Path $NuGetConfigFile -PathType Leaf)) {
 if ($Version -ne '')
 {
     $installed = & dotnet tool list -g | select-string -Pattern "$Name\s+$Version"
-    if ($installed -eq $null)
+    if ($null -eq $installed)
     {
         & dotnet tool update --global $Name --version $Version --configfile $NuGetConfigFile
     }
@@ -19,7 +19,7 @@ if ($Version -ne '')
 else
 {
     $installed = & dotnet tool list -g | select-string -Pattern "$Name"
-    if ($installed -eq $null)
+    if ($null -eq $installed)
     {
         & dotnet tool update --global $Name --configfile $NuGetConfigFile
     }


### PR DESCRIPTION
This change fixes nbgv pulling from nuget.org in the dos portion of the build.  I've also included other updates from wdkmetadata that improve log retention and separation of restore/build tasks (https://github.com/microsoft/wdkmetadata/pull/84).