### PR TITLE
Philnach/ngbvcentralize

### DIFF
--- a/AzurePipelinesTemplates/win32metadata-onebranch.yml
+++ b/AzurePipelinesTemplates/win32metadata-onebranch.yml
@@ -53,7 +53,7 @@ stages:
         targetType: inline
         workingDirectory: ${{parameters.RepoDirectory}}
         script: |
-          .\scripts\Install-DotNetTool.ps1 -Name nbgv -NuGetConfigFile '$(Build.SourcesDirectory)\${{parameters.RepoDirectory}}\nuget.config'
+          .\scripts\Install-ngbv.ps1 -NuGetConfigFile '$(Build.SourcesDirectory)\${{parameters.RepoDirectory}}\nuget.config'
           nbgv cloud --common-vars
 
     # Generate the Azure Devops pipeline build number, since nbgv cannot do it for OneBranch pipelines

--- a/scripts/CommonUtils.ps1
+++ b/scripts/CommonUtils.ps1
@@ -67,7 +67,7 @@ function Install-BuildTools
 {
     Param([switch]$Clean)
 
-    & "$PSScriptRoot\Install-ngbv.ps1" -Name nbgv -Version 3.7.115 -NuGetConfigFile "$rootDir\nuget.Config"
+    & "$PSScriptRoot\Install-ngbv.ps1" -NuGetConfigFile "$rootDir\nuget.Config"
 
     if ($Clean.IsPresent)
     {

--- a/scripts/CommonUtils.ps1
+++ b/scripts/CommonUtils.ps1
@@ -67,7 +67,7 @@ function Install-BuildTools
 {
     Param([switch]$Clean)
 
-    & "$PSScriptRoot\Install-DotNetTool" -Name nbgv -NuGetConfigFile "$rootDir\nuget.Config"
+    & "$PSScriptRoot\Install-ngbv.ps1" -Name nbgv -Version 3.7.115 -NuGetConfigFile "$rootDir\nuget.Config"
 
     if ($Clean.IsPresent)
     {

--- a/scripts/Install-ngbv.ps1
+++ b/scripts/Install-ngbv.ps1
@@ -1,0 +1,11 @@
+# Centralized script to install the nbgv tool using the Install-DotNetTool.ps1 script.
+# When switching to a newer version of nbgv tool, update the version number in this script
+# and make sure the Azure Artificats feed: https://pkgs.dev.azure.com/shine-oss/Win32Metadata/_packaging/Win32Metadata-Dependencies/nuget/v3/index.json
+# has the new version available.
+Param ([string] $NuGetConfigFile)
+
+if (-not $NuGetConfigFile) {
+    throw "NuGetConfigFile is null. NuGetConfigFile must be a valid file path to a NuGet.config file."
+}
+
+& "$PSScriptRoot\Install-DotNetTool.ps1" -Name nbgv -Version 3.7.115 -NuGetConfigFile $NuGetConfigFile


### PR DESCRIPTION
This pull request Fixes #2056 and includes changes to the build and script files to streamline the installation process of the `nbgv` tool by centralizing the installation script and updating references to it.

### Centralizing `nbgv` tool installation:

* [`AzurePipelinesTemplates/win32metadata-onebranch.yml`](diffhunk://#diff-3b729f59f59aff701b9401f928eddc1dea49618f153ae68ee48bbb4558e25d09L56-R56): Updated the script to use the new `Install-ngbv.ps1` script for installing the `nbgv` tool.
* [`scripts/CommonUtils.ps1`](diffhunk://#diff-3cffed3ca0c73656a3d863387bce402cb6bcba7d5a29ccef2f3596104350cafaL70-R70): Modified the `Install-BuildTools` function to reference the new `Install-ngbv.ps1` script.
* [`scripts/Install-ngbv.ps1`](diffhunk://#diff-6a4aaba6f670af4db47406946ae5a94810fc6bf2a1f60c7e03a368ee51e5a805R1-R11): Added a new centralized script to install the `nbgv` tool, ensuring consistent versioning and configuration across the project.