### PR TITLE
Expose NtCreateNamedPipeFile

### DIFF
--- a/generation/WinSDK/Partitions/WinProg/settings.rsp
+++ b/generation/WinSDK/Partitions/WinProg/settings.rsp
@@ -12,6 +12,7 @@ _THREADINFOCLASS
 _UNICODE_STRING
 NtClose
 NtCreateFile
+NtCreateNamedPipeFile
 NtDeviceIoControlFile
 NtNotifyChangeMultipleKeys
 NtOpenFile

--- a/generation/WinSDK/RecompiledIdlHeaders/um/winternl.h
+++ b/generation/WinSDK/RecompiledIdlHeaders/um/winternl.h
@@ -487,6 +487,29 @@ NtOpenFile (
 
 //
 // use the Win32 API instead
+//     CreateNamedPipeA
+//
+__kernel_entry NTSTATUS
+NTAPI
+NtCreateNamedPipeFile(
+  OUT PHANDLE FileHandle,
+  IN ULONG DesiredAccess,
+  IN POBJECT_ATTRIBUTES ObjectAttributes,
+  OUT PIO_STATUS_BLOCK IoStatusBlock,
+  IN ULONG ShareAccess,
+  IN ULONG CreateDisposition,
+  IN ULONG CreateOptions,
+  IN ULONG NamedPipeType,
+  IN ULONG ReadMode,
+  IN ULONG CompletionMode,
+  IN ULONG MaximumInstances,
+  IN ULONG InboundQuota,
+  IN ULONG OutboundQuota,
+  IN PLARGE_INTEGER DefaultTimeout OPTIONAL
+);
+
+//
+// use the Win32 API instead
 //     N/A
 //
 __kernel_entry NTSTATUS


### PR DESCRIPTION
This PR adds `NtCreateNamedPipeFile` (https://learn.microsoft.com/en-us/windows/win32/devnotes/nt-create-named-pipe-file) to the list of available binding signatures, this function is used to provide support for asynchronous access for pseudo-terminals via ConHost: https://github.com/microsoft/terminal/blob/2d64a3a4ab0d0d1c5b9085a022f5319460ef68d7/src/types/utils.cpp#L851