### PR TITLE
Reference the "Riverside.Win32" Win32 metadata projection in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ To call Win32 APIs from the language of your choice based off of this metadata, 
 * Dart - https://github.com/halildurmus/win32 (Community)
 * Python - https://github.com/ynkdir/py-win32more (Community)
 * Zig - https://github.com/marlersoft/zigwin32 (Community)
+* .NET Standard - https://github.com/Lamparter/Win32 (Community)
 
 Note: Community projects are listed here to help with discovery but are not officially validated by Microsoft.
 

--- a/docs/projections.md
+++ b/docs/projections.md
@@ -24,6 +24,7 @@ To call Win32 APIs from the language of your choice based off of this metadata, 
 * Dart - https://github.com/halildurmus/win32 (Community)
 * Python - https://github.com/ynkdir/py-win32more (Community)
 * Zig - https://github.com/marlersoft/zigwin32 (Community)
+* .NET Standard - https://github.com/Lamparter/Win32 (Community)
 
 Note: Community projects are listed here to help with discovery but are not officially validated by Microsoft.
 


### PR DESCRIPTION
Hi!

I've recently been working on a little project, simply titled 'Riverside.Win32', that uses some tricks to generate Win32 methods/structs/enums/etc. from the Win32 metadata (this repo!) that work across .NET (rather than using the generator approach CsWin32 uses, this makes all code completely static and available over [an array of packages](https://github.com/Lamparter/Win32/blob/main/README.md) that are specific to each Win32 library it is built from).

Having a strong Win32 PInvoke binding for all .NET languages, including VB.NET, F#, IronPython, C++/CLI and others is a much wanted product however CsWin32, being a source generator, is only capable of building generations for one language: C#.
So, I created the Riverside.Win32 project, which creates bindings from the Win32 metadata via CsWin32 and publishes it [to NuGet](https://nuget.org/packages/Riverside.Win32) for extreme ease-of-use.

It would be nice to get a little recognition for it since I've seen many ask for this kind of package before, with little answer.

Thanks!