### PR TITLE
Add Dependabot configuration for .NET SDK updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,13 +3,16 @@ registries:
   nuget-azure-devops:
     type: nuget-feed
     # The URL of the NuGet feed to check for updates
+
     url: https://pkgs.dev.azure.com/shine-oss/Win32Metadata/_packaging/Win32Metadata-Dependencies/nuget/v3/index.json
 updates:
   # Enable version updates for nuget
   - package-ecosystem: "nuget"
     # Look for NuGet dependency info from the `root` directory
+
     directory: "/"
     # Check the nuget registry for updates monthly
+
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 10
@@ -22,3 +25,13 @@ updates:
       nuget-dependencies:
         dependency-type: production
         applies-to: security-updates
+  - package-ecosystem: dotnet-sdk
+    directory: /
+    schedule:
+      interval: weekly
+      day: wednesday
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor


### PR DESCRIPTION
This PR adds Dependabot configuration to automatically manage .NET SDK version updates in global.json.

This configuration will:
- Monitor the global.json file for .NET SDK version updates
- Create pull requests when new SDK versions are available
- Help keep the project secure with the latest SDK patches

For more information, see: https://devblogs.microsoft.com/dotnet/using-dependabot-to-manage-dotnet-sdk-updates/