### PR TITLE
Annotate `RasEnumConnections[A/W]`

### DIFF
--- a/generation/WinSDK/emitter.settings.rsp
+++ b/generation/WinSDK/emitter.settings.rsp
@@ -2367,3 +2367,5 @@ IPsecSaEnum0::enumHandle=IPSEC_SA_ENUM_HANDLE
 IPsecSaEnum1::enumHandle=IPSEC_SA_ENUM_HANDLE
 IPsecSaDestroyEnumHandle0::enumHandle=IPSEC_SA_ENUM_HANDLE
 ITfCandidateListUIElement::GetPageIndex::pIndex=[Optional]
+RasEnumConnectionsA::param0=[NativeArrayInfo(CountParamIndex = 2), MemorySize(BytesParamIndex = 1)]
+RasEnumConnectionsW::param0=[NativeArrayInfo(CountParamIndex = 2), MemorySize(BytesParamIndex = 1)]

--- a/scripts/ChangesSinceLastRelease.txt
+++ b/scripts/ChangesSinceLastRelease.txt
@@ -65,3 +65,6 @@ Windows.Win32.NetworkManagement.WindowsFilteringPlatform.IPSEC_SA_CONTEXT_ENUM_H
 Windows.Win32.NetworkManagement.WindowsFilteringPlatform.IPSEC_SA_ENUM_HANDLE added
 # Make ITfCandidateListUIElement::GetPageIndex pIndex parameter optional
 Windows.Win32.UI.TextServices.ITfCandidateListUIElement.GetPageIndex : pIndex : [NativeArrayInfo(CountParamIndex=1),Out] => [NativeArrayInfo(CountParamIndex=1),Optional,Out]
+# Annotate RasEnumConnections function parameters
+Windows.Win32.NetworkManagement.Rras.Apis.RasEnumConnectionsA : param0 : [In,Optional,Out] => [In,MemorySize(BytesParamIndex=1),NativeArrayInfo(CountParamIndex=2),Optional,Out]
+Windows.Win32.NetworkManagement.Rras.Apis.RasEnumConnectionsW : param0 : [In,Optional,Out] => [In,MemorySize(BytesParamIndex=1),NativeArrayInfo(CountParamIndex=2),Optional,Out]


### PR DESCRIPTION
Fixes: https://github.com/microsoft/win32metadata/issues/2205

Verified with local metadata build that CsWin32 emites first parameter as `Span` after the change