### PR TITLE
Run PR Validation on push to main so status checks appear in branch protection picker

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -15,6 +15,11 @@ on:
     paths-ignore:
       - 'apidocs/**'
       - 'docs/**'
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'apidocs/**'
+      - 'docs/**'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
﻿## Why

The `PR Validation` workflow currently only triggers on `pull_request` (and `workflow_dispatch`), so its check-runs are never recorded against commits on `main`. GitHub's branch-protection **"Status checks that have run recently"** autocomplete dropdown is populated from check runs observed on the protected branch's recent commits — since `main` itself has none of these jobs in its history, the dropdown stays empty and you can't pick `Scrape headers: x64`/`x86`/`arm64` or `Build, test, package` to require them.

Verified with:

```
$ gh api repos/microsoft/win32metadata/commits/main/check-runs
{"total_count":0,"check_runs":[]}
```

## What this change does

Adds a `push: branches: [main]` trigger (with the same `paths-ignore` as the `pull_request` trigger) so the same matrix of jobs runs after every merge to `main`.

```yaml
on:
  pull_request:
    branches: [main]
    paths-ignore:
      - ''apidocs/**''
      - ''docs/**''
  push:
    branches: [main]
    paths-ignore:
      - ''apidocs/**''
      - ''docs/**''
  workflow_dispatch:
```

## Effect

- After the first post-merge run, `Scrape headers: x64`, `Scrape headers: x86`, `Scrape headers: arm64`, and `Build, test, package` will appear in the branch-protection status-check picker at https://github.com/microsoft/win32metadata/settings/branch_protection_rules/23707585 and can be marked required.
- `main` also gets post-merge validation, catching any breakage that slips through PR validation (e.g. semantic merge conflicts between two PRs).
- No change to PR behavior. The existing `concurrency` group still groups PR runs by PR number and `push` runs by `github.ref` (i.e. `refs/heads/main`); `cancel-in-progress: true` already applied to PRs, and applies to main pushes the same way (a newer push will cancel an in-flight main run — acceptable, but happy to switch to `cancel-in-progress: false` for `main` if preferred).

## Alternatives considered

- **Type the check names manually** in the branch protection UI — works, but brittle if names change and the dropdown remains empty for future maintainers.
- **Migrate to a Repository Ruleset** that requires a workflow by file path — cleanest long-term, but a larger change. This PR is the minimal fix.