### PR TITLE
Add Win32MetadataScraper to signed files list

### DIFF
--- a/AzurePipelinesTemplates/win32metadata-onebranch.yml
+++ b/AzurePipelinesTemplates/win32metadata-onebranch.yml
@@ -216,6 +216,8 @@ stages:
           bin/Release/net8.0/ICSharpCode.Decompiler.dll;
           bin/Release/net8.0/MetadataTasks.dll;
           bin/Release/net8.0/MetadataUtils.dll;
+          bin/Release/net8.0/win-x64/Win32MetadataScraper.dll;
+          bin/Release/net8.0/win-x64/Win32MetadataScraper.exe;
           bin/Release/net8.0/WinmdUtils.dll;
           bin/Windows.Win32.winmd;
           scripts/*.ps1;


### PR DESCRIPTION
These DLLs need to be signed if they are part of the release package. 