### PR TITLE
Add ClangSharp and libclang to job-level CodeSign exclusions

### DIFF
--- a/AzurePipelinesTemplates/win32metadata-onebranch.yml
+++ b/AzurePipelinesTemplates/win32metadata-onebranch.yml
@@ -147,7 +147,7 @@ stages:
       ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
       ob_artifactBaseName: 'NuGetPackages'
       ob_sdl_binskim_break: true # https://aka.ms/obpipelines/sdl
-      ob_sdl_codeSignValidation_excludes: -|**\Humanizer.dll;-|**\Newtonsoft.Json.dll;-|**\System.IO.Abstractions.dll;-|**\TestableIO.System.IO.Abstractions.dll;-|**\TestableIO.System.IO.Abstractions.Wrappers.dll
+      ob_sdl_codeSignValidation_excludes: -|**\Humanizer.dll;-|**\Newtonsoft.Json.dll;-|**\System.IO.Abstractions.dll;-|**\TestableIO.System.IO.Abstractions.dll;-|**\TestableIO.System.IO.Abstractions.Wrappers.dll;-|**\ClangSharp*.dll;-|**\libclang*.dll;-|**\libClangSharp*.dll
     pool:
       type: windows
     steps:

--- a/AzurePipelinesTemplates/win32metadata-onebranch.yml
+++ b/AzurePipelinesTemplates/win32metadata-onebranch.yml
@@ -147,7 +147,9 @@ stages:
       ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
       ob_artifactBaseName: 'NuGetPackages'
       ob_sdl_binskim_break: true # https://aka.ms/obpipelines/sdl
-      ob_sdl_codeSignValidation_excludes: -|**\Humanizer.dll;-|**\Newtonsoft.Json.dll;-|**\System.IO.Abstractions.dll;-|**\TestableIO.System.IO.Abstractions.dll;-|**\TestableIO.System.IO.Abstractions.Wrappers.dll;-|**\ClangSharp.dll;-|**\ClangSharp.Interop.dll;-|**\ClangSharp.PInvokeGenerator.dll;-|**\libclang*.dll;-|**\libClangSharp*.dll
+      ob_sdl_codeSignValidation_excludes: -|**\Humanizer.dll;-|**\Newtonsoft.Json.dll;-|**\System.IO.Abstractions.dll;-|**\TestableIO.System.IO.Abstractions.dll;-|**\TestableIO.System.IO.Abstractions.Wrappers.dll;-|**\ClangSharp.dll;-|**\ClangSharp.Interop.dll;-|**\ClangSharp.PInvokeGenerator.dll;-|**\libclang*.dll;-|**\libClangSharp*.dll
+
+
     pool:
       type: windows
     steps:

--- a/AzurePipelinesTemplates/win32metadata-onebranch.yml
+++ b/AzurePipelinesTemplates/win32metadata-onebranch.yml
@@ -147,7 +147,7 @@ stages:
       ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
       ob_artifactBaseName: 'NuGetPackages'
       ob_sdl_binskim_break: true # https://aka.ms/obpipelines/sdl
-      ob_sdl_codeSignValidation_excludes: -|**\Humanizer.dll;-|**\Newtonsoft.Json.dll;-|**\System.IO.Abstractions.dll;-|**\TestableIO.System.IO.Abstractions.dll;-|**\TestableIO.System.IO.Abstractions.Wrappers.dll;-|**\ClangSharp*.dll;-|**\libclang*.dll;-|**\libClangSharp*.dll
+      ob_sdl_codeSignValidation_excludes: -|**\Humanizer.dll;-|**\Newtonsoft.Json.dll;-|**\System.IO.Abstractions.dll;-|**\TestableIO.System.IO.Abstractions.dll;-|**\TestableIO.System.IO.Abstractions.Wrappers.dll;-|**\ClangSharp.dll;-|**\ClangSharp.Interop.dll;-|**\ClangSharp.PInvokeGenerator.dll;-|**\libclang*.dll;-|**\libClangSharp*.dll
     pool:
       type: windows
     steps:


### PR DESCRIPTION
These are 3P signed files, which need to be excluded from our signing stage. Component Governance stage will catch any issues with the 3P signatures.