### PR TITLE
Add IVssBackupComponents and related VSS backup interfaces

### DIFF
--- a/generation/WinSDK/Partitions/VSS/main.cpp
+++ b/generation/WinSDK/Partitions/VSS/main.cpp
@@ -17,7 +17,7 @@
 #include <vss.h>
 #include <vswriter.h>
 #include <vsmgmt.h>
-//#include <vsbackup.h> This contains C++ classes instead of COM interfaces
+#include <vsbackup.h>
 #include <vsadmin.h>
 #include <vsprov.h>
 #include <vsserror.h>

--- a/generation/WinSDK/Partitions/VSS/settings.rsp
+++ b/generation/WinSDK/Partitions/VSS/settings.rsp
@@ -4,8 +4,12 @@ CreateWriter
 CVssWriterEx
 CreateWriterEx
 CVssWriterEx2
+CreateVssBackupComponents
+CreateVssExamineWriterMetadata
+ShouldBlockRevert
 --traverse
 <IncludeRoot>/um/vsadmin.h
+<IncludeRoot>/um/vsbackup.h
 <IncludeRoot>/um/vsmgmt.h
 <IncludeRoot>/um/vsprov.h
 <IncludeRoot>/um/vss.h

--- a/scripts/ChangesSinceLastRelease.txt
+++ b/scripts/ChangesSinceLastRelease.txt
@@ -67,3 +67,22 @@ Windows.Win32.System.ApplicationInstallationAndServicing.Apis.MsiDatabaseGenerat
 Windows.Win32.System.ApplicationInstallationAndServicing.Apis.MsiDatabaseGenerateTransformA : iReserved2 : [In] => [In,Reserved]
 Windows.Win32.System.ApplicationInstallationAndServicing.Apis.MsiDatabaseGenerateTransformW : iReserved1 : [In] => [In,Reserved]
 Windows.Win32.System.ApplicationInstallationAndServicing.Apis.MsiDatabaseGenerateTransformW : iReserved2 : [In] => [In,Reserved]
+# Add IVssBackupComponents and related VSS backup interfaces from vsbackup.h (fixes #2095)
+Windows.Win32.Storage.Vss.Apis.CreateVssBackupComponentsInternal added
+Windows.Win32.Storage.Vss.Apis.CreateVssExamineWriterMetadataInternal added
+Windows.Win32.Storage.Vss.Apis.GetProviderMgmtInterfaceInternal added
+Windows.Win32.Storage.Vss.Apis.IsVolumeSnapshottedInternal added
+Windows.Win32.Storage.Vss.Apis.ShouldBlockRevertInternal added
+Windows.Win32.Storage.Vss.Apis.VSS_SW_BOOTABLE_STATE added
+Windows.Win32.Storage.Vss.Apis.VssFreeSnapshotPropertiesInternal added
+Windows.Win32.Storage.Vss.IVssBackupComponents added
+Windows.Win32.Storage.Vss.IVssBackupComponentsEx added
+Windows.Win32.Storage.Vss.IVssBackupComponentsEx2 added
+Windows.Win32.Storage.Vss.IVssBackupComponentsEx3 added
+Windows.Win32.Storage.Vss.IVssBackupComponentsEx4 added
+Windows.Win32.Storage.Vss.IVssExamineWriterMetadata added
+Windows.Win32.Storage.Vss.IVssExamineWriterMetadataEx added
+Windows.Win32.Storage.Vss.IVssExamineWriterMetadataEx2 added
+Windows.Win32.Storage.Vss.IVssWMComponent added
+Windows.Win32.Storage.Vss.IVssWriterComponentsExt added
+Windows.Win32.Storage.Vss.VSS_COMPONENTINFO added


### PR DESCRIPTION
﻿## Summary

Adds `IVssBackupComponents` and related VSS backup interfaces to the winmd by including `vsbackup.h` in the VSS partition.

Fixes #2095

## Changes

**`generation/WinSDK/Partitions/VSS/main.cpp`**
- Uncommented `#include <vsbackup.h>` — the header was previously excluded with the note "This contains C++ classes instead of COM interfaces", but the types are standard COM interfaces (`IUnknown`-derived, pure virtual methods) declared using C++ class syntax with `__declspec(uuid(...))`. ClangSharp handles these correctly.

**`generation/WinSDK/Partitions/VSS/settings.rsp`**
- Added `<IncludeRoot>/um/vsbackup.h` to the `--traverse` list
- Added `--exclude` entries for inline wrapper functions (`CreateVssBackupComponents`, `CreateVssExamineWriterMetadata`, `ShouldBlockRevert`) — these are not real DLL exports; the `*Internal` variants are the actual exports and are already mapped to `VSSAPI.dll` in `libMappings.rsp`

**`scripts/ChangesSinceLastRelease.txt`**
- Updated with the expected winmd differences

## New types exposed

| Interface | UUID |
|-----------|------|
| `IVssBackupComponents` | `665c1d5f-c218-414d-a05d-7fef5f9d5c86` |
| `IVssBackupComponentsEx` | `963f03ad-9e4c-4a34-ac15-e4b6174e5036` |
| `IVssBackupComponentsEx2` | `acfe2b3a-22c9-4ef8-bd03-2f9ca230084e` |
| `IVssBackupComponentsEx3` | `c191bfbc-b602-4675-8bd1-67d642f529d5` |
| `IVssBackupComponentsEx4` | `f434c2fd-b553-4961-a9f9-a8e90b673e53` |
| `IVssExamineWriterMetadata` | `902fcf7f-b7fd-42f8-81f1-b2e400b1e5bd` |
| `IVssExamineWriterMetadataEx` | `0c0e5ec0-ca44-472b-b702-e652db1c0451` |
| `IVssExamineWriterMetadataEx2` | `ce115780-a611-431b-b57f-c38303ab6aee` |
| `IVssWMComponent` | *(no uuid in SDK header)* |
| `IVssWriterComponentsExt` | *(no uuid in SDK header)* |

## New functions exposed

- `CreateVssBackupComponentsInternal`
- `CreateVssExamineWriterMetadataInternal`
- `IsVolumeSnapshottedInternal`
- `VssFreeSnapshotPropertiesInternal`
- `GetProviderMgmtInterfaceInternal`
- `ShouldBlockRevertInternal`

## Known limitations (pre-existing SDK/tooling issues, not blocking)

- **`IVssWriterComponentsExt` vtable slot collision**: This interface uses diamond multiple inheritance (`IVssWriterComponents` + `IUnknown`) in the SDK header. ClangSharp maps both `GetComponentCount` and `QueryInterface` to `lpVtbl[0]`, etc. In practice this interface is a marker type with an empty body — consumers get `IVssBackupComponents` via `CreateVssBackupComponentsInternal` and use `QueryInterface` on that instead.
- **`IVssWMComponent` and `IVssWriterComponentsExt` lack GUIDs**: The SDK headers don't declare UUIDs for these interfaces, so `QueryInterface` can't target them directly.
- **`SaveAsXML` parameter `pbstrXML` is annotated `_In_` instead of `_Out_`**: This is a bug in the Windows SDK header (`vsbackup.h`) that is faithfully reproduced.