### PR TITLE
Remove unsupported property from build_winmd

### DIFF
--- a/AzurePipelinesTemplates/win32metadata-onebranch.yml
+++ b/AzurePipelinesTemplates/win32metadata-onebranch.yml
@@ -140,8 +140,6 @@ stages:
   jobs:
   - job: build_winmd
     displayName: Build, test, sign, package winmd
-    workspace:
-      clean: all
     variables:
       OutputPackagesDir: $(Build.SourcesDirectory)\${{parameters.RepoDirectory}}\bin\Packages\Release\NuGet
       ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'


### PR DESCRIPTION
OneBranch/1ES governed templates reject the 'workspace' job property ("Job property 'workspace' is not allowed"), which fails template validation in the Build WinMD stage. OneBranch jobs already run in a clean, isolated container workspace, so 'clean: all' is redundant.