### PR TITLE
Pin Newtonsoft.Json to 13.0.1 in Win32MetadataScraperTests (CVE-2024-21907)

### DIFF
--- a/tests/Win32MetadataScraperTests/Win32MetadataScraperTests.csproj
+++ b/tests/Win32MetadataScraperTests/Win32MetadataScraperTests.csproj
@@ -9,6 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <!-- Pins the Newtonsoft.Json brought in transitively by Microsoft.NET.Test.Sdk to a version without CVE-2024-21907. -->
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Why is this change being made?

S360 flagged a high-severity Component Governance alert against `Newtonsoft.Json 9.0.1` in this repo, at `/tests/Win32MetadataScraperTests/Win32MetadataScraperTests.csproj` on branch `main`:

- **CVE-2024-21907** — improper handling of exceptional conditions in `Newtonsoft.Json` prior to `13.0.1`; crafted input can cause a `StackOverflowException` (DoS). Fixed in **13.0.1**.

Tracked by AB#63114278.

The package is not referenced directly anywhere in the project. It arrives transitively: `Microsoft.NET.Test.Sdk 17.3.2` → `Microsoft.TestPlatform.TestHost` → `Newtonsoft.Json 9.0.1`. `Win32MetadataScraperTests` was the only test project in the repo that had not already pinned it.

## What changed?

- `tests/Win32MetadataScraperTests/Win32MetadataScraperTests.csproj`: added a direct `<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />` (with a short comment explaining why), so the direct reference wins over the vulnerable transitive resolution.

`13.0.1` was chosen deliberately over a newer 13.x to match the version already used everywhere else in the repo — `sources/MetadataUtils`, `sources/GeneratorSdk/MetadataTasks`, `tests/Windows.Win32.Tests`, and `tests/VtablesFromPdb` are all on `13.0.1` — keeping a single Newtonsoft.Json version across the build and avoiding any binding-redirect or assembly-unification surprises in the MSBuild task host.

This repo does not use central package management, so the fix has to be applied per-project; no `Directory.Packages.props` exists to change.

## How was the change tested?

The precedent is already proven in-repo: `tests/Windows.Win32.Tests/Windows.Win32.Tests.csproj` uses the exact same combination (`Microsoft.NET.Test.Sdk 17.3.2` + `Newtonsoft.Json 13.0.1`) and is *not* flagged by Component Governance — which is direct evidence that this pinning pattern clears the alert.

Verified locally on Windows with the repo's pinned SDK:

```
dotnet restore tests\Win32MetadataScraperTests\Win32MetadataScraperTests.csproj
```

Inspected the generated `obj\Win32MetadataScraperTests\project.assets.json` to confirm the graph actually resolved to the fixed version and that `9.0.1` is gone entirely:

```
Newtonsoft.Json/13.0.1
```

Then built it:
```
dotnet build tests\Win32MetadataScraperTests\Win32MetadataScraperTests.csproj --no-restore
```
> Build succeeded. 0 Warning(s), 0 Error(s)

Pipeline impact reviewed: `AzurePipelinesTemplates/win32metadata-onebranch.yml` already excludes `**\Newtonsoft.Json.dll` from `ob_sdl_codeSignValidation_excludes`, and this is a test-only project that is not packed or shipped, so signing/SDL behaviour is unchanged. No pipelines were queued; CI on this PR will provide full coverage.

_For more information on the code review process, see the [Code Review Guidelines & Etiquette](https://aka.ms/codereviewguidelines)._
