### PR TITLE
ci: tolerate unavailable baseline artifacts

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -180,24 +180,33 @@ jobs:
               return;
             }
 
+            if (winmdArtifact.expired) {
+              core.warning('The baseline winmd artifact has expired. Will fall back to NuGet baseline.');
+              return;
+            }
+
             // Download and extract
-            const download = await github.rest.actions.downloadArtifact({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              artifact_id: winmdArtifact.id,
-              archive_format: 'zip'
-            });
+            try {
+              const download = await github.rest.actions.downloadArtifact({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                artifact_id: winmdArtifact.id,
+                archive_format: 'zip'
+              });
 
-            const outputDir = 'bin/baseline-artifact';
-            fs.mkdirSync(outputDir, { recursive: true });
-            const zipPath = path.join(outputDir, 'artifact.zip');
-            fs.writeFileSync(zipPath, Buffer.from(download.data));
+              const outputDir = 'bin/baseline-artifact';
+              fs.mkdirSync(outputDir, { recursive: true });
+              const zipPath = path.join(outputDir, 'artifact.zip');
+              fs.writeFileSync(zipPath, Buffer.from(download.data));
 
-            // Extract using PowerShell
-            const { execSync } = require('child_process');
-            execSync(`Expand-Archive -Path "${zipPath}" -DestinationPath "${outputDir}" -Force`, { shell: 'pwsh' });
-            fs.unlinkSync(zipPath);
-            core.info(`Extracted baseline winmd to ${outputDir}`);
+              // Extract using PowerShell
+              const { execSync } = require('child_process');
+              execSync(`Expand-Archive -Path "${zipPath}" -DestinationPath "${outputDir}" -Force`, { shell: 'pwsh' });
+              fs.unlinkSync(zipPath);
+              core.info(`Extracted baseline winmd to ${outputDir}`);
+            } catch (error) {
+              core.warning(`Could not download or extract the baseline winmd artifact. Will fall back to NuGet baseline: ${error.message}`);
+            }
 
       - name: Generate API surface diff
         if: github.event_name == 'pull_request'

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -170,7 +170,7 @@ jobs:
             // Find the winmd artifact
             const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
               owner: context.repo.owner,
-              repo: context.repo.repo,
+              repo: context.repo.owner,
               run_id: runId
             });
 
@@ -348,6 +348,7 @@ jobs:
               await github.rest.issues.updateComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
+                issue_number: prNumber,
                 comment_id: existing.id,
                 body: body
               });
@@ -370,7 +371,7 @@ jobs:
             bin/current.apidump.cs
             bin/baseline.apidump.cs
             bin/api-diff.patch
-          retention-days: 30
+          retention-days: 90
 
       - name: Upload build logs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -170,7 +170,7 @@ jobs:
             // Find the winmd artifact
             const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
               owner: context.repo.owner,
-              repo: context.repo.owner,
+              repo: context.repo.repo,
               run_id: runId
             });
 
@@ -348,7 +348,6 @@ jobs:
               await github.rest.issues.updateComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: prNumber,
                 comment_id: existing.id,
                 body: body
               });

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -370,7 +370,7 @@ jobs:
             bin/current.apidump.cs
             bin/baseline.apidump.cs
             bin/api-diff.patch
-          retention-days: 30
+          retention-days: 90
 
       - name: Upload build logs
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## What changed
- Treat an expired target-branch `winmd` artifact as unavailable.
- Catch baseline artifact download/extraction failures and continue with the existing NuGet baseline fallback.
- Increase the `winmd` artifact retention from 30 to the maximum 90 days.

## Why
The PR validation job failed after all build and test steps succeeded because the baseline artifact download step propagated an artifact-availability error. Baseline retrieval is auxiliary to API diff generation and should not fail the job when the NuGet fallback is available. Retaining the artifact for 90 days also reduces how often the fallback is needed.

## Validation
- `git diff --check` passes.
- The final PR diff contains only the intended fallback-handling and retention changes.
- Build, packaging, and tests were already successful in the referenced CI run before the baseline-download step failed.

This is a draft for review.