### PR TITLE
ci: retry transient artifact upload failures

### DIFF
--- a/.github/actions/upload-artifact-with-retry/action.yml
+++ b/.github/actions/upload-artifact-with-retry/action.yml
@@ -1,0 +1,41 @@
+name: Upload artifact with retry
+description: Upload a workflow artifact and retry once after a transient failure.
+
+inputs:
+  name:
+    description: Artifact name
+    required: true
+  path:
+    description: Files or directories to upload
+    required: true
+  retention-days:
+    description: Number of days to retain the artifact
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Upload artifact
+      id: upload
+      continue-on-error: true
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.name }}
+        path: ${{ inputs.path }}
+        retention-days: ${{ inputs.retention-days }}
+
+    - name: Wait before retry
+      if: steps.upload.outcome == 'failure'
+      shell: pwsh
+      run: |
+        Write-Warning 'Artifact upload failed. Retrying in 15 seconds.'
+        Start-Sleep -Seconds 15
+
+    - name: Retry artifact upload
+      if: steps.upload.outcome == 'failure'
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.name }}
+        path: ${{ inputs.path }}
+        retention-days: ${{ inputs.retention-days }}
+        overwrite: true

--- a/.github/actions/upload-artifact-with-retry/action.yml
+++ b/.github/actions/upload-artifact-with-retry/action.yml
@@ -1,6 +1,9 @@
 name: Upload artifact with retry
 description: Upload a workflow artifact and retry once after a transient failure.
 
+# Extracted from .github/workflows/pr-validation.yml to share upload behavior.
+# Retry workaround: https://github.com/actions/upload-artifact/issues/560
+
 inputs:
   name:
     description: Artifact name

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -80,14 +80,14 @@ jobs:
         run: .\scripts\GenerateMetadataSource.ps1 -arch ${{ matrix.arch }} ${{ matrix.extra_args }}
 
       - name: Upload generated assets
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload-artifact-with-retry
         with:
           name: generated_${{ matrix.arch }}
           path: generation/WinSDK/obj
           retention-days: 1
 
       - name: Upload build logs
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload-artifact-with-retry
         if: always()
         with:
           name: scrape_logs_${{ matrix.arch }}
@@ -361,7 +361,7 @@ jobs:
             }
 
       - name: Upload winmd and API dump
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload-artifact-with-retry
         if: always()
         with:
           name: winmd
@@ -373,7 +373,7 @@ jobs:
           retention-days: 90
 
       - name: Upload build logs
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload-artifact-with-retry
         if: always()
         with:
           name: build_logs
@@ -381,7 +381,7 @@ jobs:
           retention-days: 7
 
       - name: Upload NuGet packages
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload-artifact-with-retry
         with:
           name: NuGetPackages
           path: bin/Packages/Release/NuGet


### PR DESCRIPTION
﻿## Summary
- add a local composite action that retries artifact uploads once after 15 seconds
- use `overwrite: true` on the retry to handle a partially finalized first attempt
- apply the retry wrapper to generated assets, logs, winmd/API dumps, and NuGet packages

## Motivation
The `main` workflow uploaded all NuGet package bytes but received an intermittent HTTP 403 while finalizing the artifact. The unchanged rerun succeeded. This matches the known `actions/upload-artifact` failure tracked in actions/upload-artifact#560.

A second upload failure still fails the workflow, so persistent configuration or service errors remain visible.

## Validation
- `git diff --check`