### PR TITLE
Add the missing webauthnplugin.h APIs to the metadata

### DIFF
--- a/generation/WinSDK/libMappingsManual.rsp
+++ b/generation/WinSDK/libMappingsManual.rsp
@@ -385,3 +385,30 @@ VDMConsoleOperation=KERNEL32.dll
 VerifyConsoleIoHandle=KERNEL32.dll
 WriteConsoleInputVDMA=KERNEL32.dll
 WriteConsoleInputVDMW=KERNEL32.dll
+# webauthnplugin.h APIs are exported from webauthn.dll but have no import library in the SDK.
+# The documentation lists WebAuthnPlugin.dll/WebAuthnPlugin.Lib, but neither ships in the SDK
+# or in Windows; LoadLibrary("WebAuthnPlugin.dll") fails with ERROR_MOD_NOT_FOUND.
+WebAuthNPluginGetAuthenticatorState=webauthn.dll
+WebAuthNPluginAddAuthenticator=webauthn.dll
+WebAuthNPluginFreeAddAuthenticatorResponse=webauthn.dll
+WebAuthNPluginRemoveAuthenticator=webauthn.dll
+WebAuthNPluginUpdateAuthenticatorDetails=webauthn.dll
+WebAuthNPluginAuthenticatorAddCredentials=webauthn.dll
+WebAuthNPluginAuthenticatorRemoveCredentials=webauthn.dll
+WebAuthNPluginAuthenticatorRemoveAllCredentials=webauthn.dll
+WebAuthNPluginAuthenticatorGetAllCredentials=webauthn.dll
+WebAuthNPluginAuthenticatorFreeCredentialDetailsArray=webauthn.dll
+WebAuthNPluginPerformUserVerification=webauthn.dll
+WebAuthNPluginFreeUserVerificationResponse=webauthn.dll
+WebAuthNPluginGetUserVerificationCount=webauthn.dll
+WebAuthNPluginGetUserVerificationPublicKey=webauthn.dll
+WebAuthNPluginGetOperationSigningPublicKey=webauthn.dll
+WebAuthNPluginFreePublicKeyResponse=webauthn.dll
+WebAuthNEncodeMakeCredentialResponse=webauthn.dll
+WebAuthNDecodeMakeCredentialRequest=webauthn.dll
+WebAuthNFreeDecodedMakeCredentialRequest=webauthn.dll
+WebAuthNDecodeGetAssertionRequest=webauthn.dll
+WebAuthNFreeDecodedGetAssertionRequest=webauthn.dll
+WebAuthNEncodeGetAssertionResponse=webauthn.dll
+WebAuthNPluginRegisterStatusChangeCallback=webauthn.dll
+WebAuthNPluginUnregisterStatusChangeCallback=webauthn.dll


### PR DESCRIPTION
> [!NOTE]
> Parts of this PR have been generated with GitHub Copilot.

## Summary

The `WebAuthn` partition already traverses [`webauthnplugin.h`](https://learn.microsoft.com/en-us/windows/win32/api/webauthnplugin/), so its structs, enums and delegates were emitted — but **the entire function surface of the header was silently dropped** from the winmd.

`libMappings.rsp` is generated by scanning the SDK's import libraries, and none of these entrypoints live in one (`webauthn.lib` only covers the `webauthn.h` surface). With no library mapping the scraper emits `DllImport("")`, and `MetadataSyntaxTreeCleaner` drops any method whose import lib is unknown — with no warning, which is why this went unnoticed.

This adds the missing entrypoints to `libMappingsManual.rsp`, which `CONTRIBUTING.md` documents as the place for "entrypoints not present in import libs".

## Scope: stable APIs only

This PR covers the **24 stable entrypoints** in `webauthnplugin.h`. The three `EXPERIMENTAL_` functions in the header are deliberately left out:

- `EXPERIMENTAL_WebAuthNPluginAddAuthenticator2`
- `EXPERIMENTAL_WebAuthNPluginUpdateAuthenticatorDetails2`
- `EXPERIMENTAL_WebAuthNPluginPerformUserVerification2`

Experimental APIs are subject to renaming and removal between SDK releases — these three have in fact already lost the `EXPERIMENTAL_` prefix in newer builds — so projecting them into the metadata would bake in names that are not stable. The `EXPERIMENTAL_` functions declared in `webauthn.h` are excluded for the same reason.

## Which DLL?

All 24 functions are exported from **`webauthn.dll`**, verified with `dumpbin /exports` against `C:\Windows\System32\webauthn.dll`. The header carries no `import_library` annotation, so `libMappingsManual.rsp` is the correct place.

The documentation lists `WebAuthnPlugin.dll` / `WebAuthnPlugin.Lib`, but that appears to be a doc authoring artifact:

- No `WebAuthnPlugin.lib` ships in the Windows SDK (only `webauthn.lib`).
- No `WebAuthnPlugin.dll` exists anywhere under `C:\Windows`.
- `LoadLibraryW("WebAuthnPlugin.dll")` fails with `ERROR_MOD_NOT_FOUND` (126), so mapping to it would make every P/Invoke fail at runtime.

## API changes

24 functions added to `Windows.Win32.Security.Authentication.WebAuthn.Apis`, all emitting `[DllImport("webauthn.dll", ExactSpelling = true, PreserveSig = false)]`:

`WebAuthNPluginGetAuthenticatorState`, `WebAuthNPluginAddAuthenticator`, `WebAuthNPluginFreeAddAuthenticatorResponse`, `WebAuthNPluginRemoveAuthenticator`, `WebAuthNPluginUpdateAuthenticatorDetails`, `WebAuthNPluginAuthenticatorAddCredentials`, `WebAuthNPluginAuthenticatorRemoveCredentials`, `WebAuthNPluginAuthenticatorRemoveAllCredentials`, `WebAuthNPluginAuthenticatorGetAllCredentials`, `WebAuthNPluginAuthenticatorFreeCredentialDetailsArray`, `WebAuthNPluginPerformUserVerification`, `WebAuthNPluginFreeUserVerificationResponse`, `WebAuthNPluginGetUserVerificationCount`, `WebAuthNPluginGetUserVerificationPublicKey`, `WebAuthNPluginGetOperationSigningPublicKey`, `WebAuthNPluginFreePublicKeyResponse`, `WebAuthNEncodeMakeCredentialResponse`, `WebAuthNDecodeMakeCredentialRequest`, `WebAuthNFreeDecodedMakeCredentialRequest`, `WebAuthNDecodeGetAssertionRequest`, `WebAuthNFreeDecodedGetAssertionRequest`, `WebAuthNEncodeGetAssertionResponse`, `WebAuthNPluginRegisterStatusChangeCallback`, `WebAuthNPluginUnregisterStatusChangeCallback`

No types were added, removed or moved — the supporting structs/enums/delegates were already in the metadata.

## Validation

`./DoAll.ps1 -ExcludePackages -ExcludeSamples` — build succeeded, all tests pass:

- `MetadataUtils.Tests` — 17/17
- `Win32MetadataScraperTests` — 44/44
- `Windows.Win32.Tests` — 13/13 (includes `NoSuggestedRemappings`, empty-delegate and duplicate-import checks)

Note: that run was performed on the earlier revision of this branch, which also mapped the experimental entrypoints. This revision only *removes* mappings from that set, so it is a strict subset; the expected winmd delta is the 24 additions listed above (`webauthn.dll` imports going from 15 to 39).

## Notes / possible follow-ups

Out of scope here, but surfaced while investigating:

- The build emits `warning CSSW001` suggesting `WebAuthn` be added to `<ExcludeFromCrossarch>` in `Windows.Win32.proj`; the partition has no cross-arch differences. Pre-existing since the partition was introduced, left alone to keep this diff surgical.
- Incremental builds don't pick up scraper-only `.rsp` edits: `ScrapeHeaders` skips partitions whose own sources are unchanged, and `EmitWinmd`'s `Inputs` don't include the generated `.cs`. Validating a change like this locally requires deleting `obj/generated/scannedheaders.*.txt` and `bin/Windows.Win32.winmd` first, otherwise the build silently reports no API changes.