### PR TITLE
Fix broken PR workflow around API diffs for fork PRs

### DIFF
--- a/.github/workflows/pr-api-diff-comment.yml
+++ b/.github/workflows/pr-api-diff-comment.yml
@@ -1,0 +1,129 @@
+name: PR API Diff Comment
+
+on:
+  workflow_run:
+    workflows: [PR Validation]
+    types: [completed]
+
+permissions:
+  actions: read
+  pull-requests: write
+
+concurrency:
+  group: api-diff-comment-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  comment:
+    name: Post API diff comment
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download API diff artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: api-diff
+          path: artifact
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Post API diff comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            const workflowRun = context.payload.workflow_run;
+            if (!workflowRun.head_repository) {
+              core.setFailed('Workflow run has no head repository.');
+              return;
+            }
+
+            const head = `${workflowRun.head_repository.owner.login}:${workflowRun.head_branch}`;
+            const pullRequests = await github.paginate(github.rest.pulls.list, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'all',
+              head,
+              per_page: 100
+            });
+            const matchingPullRequests = pullRequests.filter(
+              pullRequest => pullRequest.head.sha === workflowRun.head_sha
+            );
+            if (matchingPullRequests.length !== 1) {
+              core.setFailed(
+                `Expected one pull request for ${head} at ${workflowRun.head_sha}, found ${matchingPullRequests.length}.`
+              );
+              return;
+            }
+
+            const diffPath = path.join('artifact', 'api-diff.patch');
+            if (!fs.existsSync(diffPath)) {
+              core.setFailed(`API diff artifact is missing ${diffPath}.`);
+              return;
+            }
+
+            const diff = fs.readFileSync(diffPath, 'utf8');
+            const prNumber = matchingPullRequests[0].number;
+            const runUrl = workflowRun.html_url;
+            const marker = '<!-- win32metadata-api-diff -->';
+            let body;
+
+            if (diff.trim().length === 0) {
+              body = `${marker}
+            ## 📋 API Surface Diff
+
+            ✅ No API differences vs the baseline.
+
+            [Full validation run](${runUrl})
+
+            > This comment is automatically updated on each push.`;
+            } else {
+              const diffLines = diff.split(/\r?\n/);
+              const additions = diffLines.filter(line => /^\+[^+]/.test(line)).length;
+              const deletions = diffLines.filter(line => /^-[^-]/.test(line)).length;
+              const longestBacktickRun = Math.max(0, ...Array.from(diff.matchAll(/`+/g), match => match[0].length));
+              const fence = '`'.repeat(Math.max(3, longestBacktickRun + 1));
+
+              body = `${marker}
+            ## 📋 API Surface Diff
+
+            **+${additions} additions / -${deletions} deletions** vs main branch ([full validation run](${runUrl}))
+
+            <details>
+            <summary>Click to expand API diff</summary>
+
+            ${fence}diff
+            ${diff}
+            ${fence}
+
+            </details>
+
+            > This comment is automatically updated on each push.`;
+            }
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100
+            });
+            const existing = comments.find(comment => comment.body?.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body
+              });
+            }

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -273,7 +273,7 @@ jobs:
           $global:LASTEXITCODE = 0
 
       - name: Post API diff comment on PR
-        if: github.event_name == 'pull_request' && steps.apidump.outputs.has_diff == 'true'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && steps.apidump.outputs.has_diff == 'true'
         uses: actions/github-script@v7
         with:
           script: |
@@ -327,7 +327,7 @@ jobs:
             }
 
       - name: Post no-diff comment on PR
-        if: github.event_name == 'pull_request' && steps.apidump.outputs.has_diff == 'false'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && steps.apidump.outputs.has_diff == 'false'
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -23,8 +23,8 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
-  pull-requests: write
 
 concurrency:
   group: pr-${{ github.event.pull_request.number || github.ref }}
@@ -272,93 +272,13 @@ jobs:
           # Reset LASTEXITCODE so GitHub Actions doesn't treat this step as failed
           $global:LASTEXITCODE = 0
 
-      - name: Post API diff comment on PR
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && steps.apidump.outputs.has_diff == 'true'
-        uses: actions/github-script@v7
+      - name: Upload API diff
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/upload-artifact-with-retry
         with:
-          script: |
-            const fs = require('fs');
-            const diff = fs.readFileSync('bin/api-diff.patch', 'utf8');
-            const prNumber = context.payload.pull_request.number;
-            const additions = ${{ steps.apidump.outputs.additions || 0 }};
-            const deletions = ${{ steps.apidump.outputs.deletions || 0 }};
-            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-
-            const marker = '<!-- win32metadata-api-diff -->';
-            const body = `${marker}
-            ## 📋 API Surface Diff
-
-            **+${additions} additions / -${deletions} deletions** vs main branch ([full build log](${runUrl}))
-
-            <details>
-            <summary>Click to expand API diff</summary>
-
-            \`\`\`diff
-            ${diff}
-            \`\`\`
-
-            </details>
-
-            > This comment is automatically updated on each push.`;
-
-            const comments = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-              per_page: 100
-            });
-
-            const existing = comments.data.find(c => c.body.includes(marker));
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body: body
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: prNumber,
-                body: body
-              });
-            }
-
-      - name: Post no-diff comment on PR
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && steps.apidump.outputs.has_diff == 'false'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const prNumber = context.payload.pull_request.number;
-            const marker = '<!-- win32metadata-api-diff -->';
-            const body = `${marker}\n## 📋 API Surface Diff\n\n✅ No API differences vs last release.\n\n> This comment is automatically updated on each push.`;
-
-            const comments = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-              per_page: 100
-            });
-
-            const existing = comments.data.find(c => c.body.includes(marker));
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body: body
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: prNumber,
-                body: body
-              });
-            }
+          name: api-diff
+          path: bin/api-diff.patch
+          retention-days: 7
 
       - name: Upload winmd and API dump
         uses: ./.github/actions/upload-artifact-with-retry


### PR DESCRIPTION
## Summary

- Keep fork PR validation on the read-only `pull_request` security boundary.
- Upload the generated API diff as a dedicated artifact.
- Use a trusted `workflow_run` workflow to download that artifact and post or update the API-diff PR comment for both fork and same-repository contributions.

## Why

Fork PR workflows receive a read-only `GITHUB_TOKEN`, even when the workflow requests `pull-requests: write`. The validation in #2290 completed successfully, then the no-diff comment step failed with `403 Resource not accessible by integration`.

Granting the untrusted PR workflow write access would be unsafe. The split workflow follows GitHub's recommended pattern: untrusted code builds and uploads data with read-only permissions, while trusted workflow code on the default branch performs the privileged comment operation without checking out or executing contributor code.

The trusted workflow resolves the PR from the run's fork owner, branch, and exact head SHA because GitHub does not populate `workflow_run.pull_requests` for these fork runs.

## Validation

- `git diff --check`
- `actionlint .github/workflows/pr-validation.yml .github/workflows/pr-api-diff-comment.yml`
- Embedded `github-script` JavaScript syntax check with Node.js
- Downloaded #2290's `winmd` artifact and confirmed it contains the expected zero-length `api-diff.patch` for the no-diff result.
- Verified GitHub's pull-request lookup returns #2290 from `danfiedler-msft:danfiedler/pin-actions` and its exact workflow head SHA.
- Exercised comment creation and update against #2290 using the downloaded artifact and the same REST operations: https://github.com/microsoft/win32metadata/pull/2290#issuecomment-5404184028

The `workflow_run` job itself can only execute after this workflow definition exists on the default branch, which is the GitHub security boundary that gives the trusted follow-up workflow write permission.
