### PR TITLE
Prevent Guid attribute namespace shadowing

### DIFF
--- a/sources/ClangSharpSourceToWinmd/ClangSharpSourceWinmdGenerator.cs
+++ b/sources/ClangSharpSourceToWinmd/ClangSharpSourceWinmdGenerator.cs
@@ -231,7 +231,7 @@ namespace ClangSharpSourceToWinmd
 
         private static bool HasGuidAttribute(SyntaxList<AttributeListSyntax> attributeLists)
         {
-            bool ret = attributeLists.Any(list => list.Attributes.Any(attr => attr.Name.ToString() == "Windows.Win32.Foundation.Metadata.Guid"));
+            bool ret = attributeLists.Any(list => list.Attributes.Any(attr => attr.Name.ToString() == EncodeHelpers.GuidAttributeName));
             return ret;
         }
 

--- a/sources/ClangSharpSourceToWinmd/MetadataSyntaxTreeCleaner.cs
+++ b/sources/ClangSharpSourceToWinmd/MetadataSyntaxTreeCleaner.cs
@@ -318,7 +318,7 @@ namespace ClangSharpSourceToWinmd
                                     SyntaxFactory.AttributeList(
                                         SyntaxFactory.SingletonSeparatedList<AttributeSyntax>(
                                             SyntaxFactory.Attribute(
-                                                SyntaxFactory.ParseName("Windows.Win32.Foundation.Metadata.Guid"),
+                                                SyntaxFactory.ParseName(EncodeHelpers.GuidAttributeName),
                                                 SyntaxFactory.ParseAttributeArgumentList(argsFormatted))));
 
                                 node = node.AddAttributeLists(attrsList).WithLeadingTrivia(node.GetLeadingTrivia());

--- a/sources/MetadataUtils/EncodeHelpers.cs
+++ b/sources/MetadataUtils/EncodeHelpers.cs
@@ -11,6 +11,7 @@ namespace MetadataUtils
     public static class EncodeHelpers
     {
         public const string AttributeToRemoveSuffix = "__remove";
+        public const string GuidAttributeName = "global::Windows.Win32.Foundation.Metadata.Guid";
 
         private static readonly System.Text.RegularExpressions.Regex RemappedParmRegex = new System.Text.RegularExpressions.Regex(@"(?:\[([^\]]*)\])?(?:\s*(\w+\**)(?:\s+(\w+))?)?");
         private static readonly System.Text.RegularExpressions.Regex AttributeRegex = new System.Text.RegularExpressions.Regex(@"(-?\w+)(\(.+\)$)?");
@@ -400,7 +401,7 @@ namespace MetadataUtils
                 SyntaxFactory.AttributeList(
                     SyntaxFactory.SingletonSeparatedList<AttributeSyntax>(
                         SyntaxFactory.Attribute(
-                            SyntaxFactory.ParseName("Windows.Win32.Foundation.Metadata.Guid"),
+                            SyntaxFactory.ParseName(GuidAttributeName),
                             SyntaxFactory.ParseAttributeArgumentList(args))));
         }
     }

--- a/tests/ClangSharpSourceToWinmdTests/GuidAttributeTests.cs
+++ b/tests/ClangSharpSourceToWinmdTests/GuidAttributeTests.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ClangSharpSourceToWinmd;
+using MetadataUtils;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ClangSharpSourceToWinmdTests
+{
+    [TestClass]
+    public class GuidAttributeTests
+    {
+        [TestMethod]
+        public void ConvertGuidToAttributeList_TypeNamedWindows_DoesNotShadowGuidAttributeNamespace()
+        {
+            AttributeListSyntax attributeList = EncodeHelpers.ConvertGuidToAttributeList(Guid.Empty);
+            string source = @"
+namespace Windows.Win32.Foundation.Metadata
+{
+    public sealed class GuidAttribute : global::System.Attribute
+    {
+        public GuidAttribute(uint a, ushort b, ushort c, byte d, byte e, byte f, byte g, byte h, byte i, byte j, byte k)
+        {
+        }
+    }
+}
+
+namespace Test
+{
+    public sealed class Windows
+    {
+    }
+
+    public static class Constants
+    {
+        " + attributeList + @"
+        public const string Id = """";
+    }
+}";
+
+            CSharpCompilation compilation = CSharpCompilation.Create(
+                "GuidAttributeTest",
+                new[] { CSharpSyntaxTree.ParseText(source) },
+                new[] { MetadataReference.CreateFromFile(typeof(object).Assembly.Location) },
+                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+            Diagnostic[] errors = compilation.GetDiagnostics()
+                .Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+                .ToArray();
+
+            Assert.AreEqual(0, errors.Length, string.Join(Environment.NewLine, errors.Select(error => error.ToString())));
+        }
+
+        [TestMethod]
+        public void CleanSyntaxTree_GuidConstantUsesGloballyQualifiedAttribute()
+        {
+            SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(@"
+using System;
+
+namespace Test
+{
+    public static class Constants
+    {
+        public static readonly Guid Id = new Guid(""00000000-0000-0000-0000-000000000000"");
+    }
+}");
+
+            SyntaxTree cleanedTree = MetadataSyntaxTreeCleaner.CleanSyntaxTree(
+                syntaxTree,
+                new Dictionary<string, string>(),
+                new Dictionary<string, Dictionary<string, string>>(),
+                new HashSet<string>(),
+                new Dictionary<string, string>(),
+                new Dictionary<string, string>(),
+                new Dictionary<string, string>(),
+                new HashSet<string>(),
+                new HashSet<string>(),
+                "test.cs");
+
+            AttributeSyntax guidAttribute = cleanedTree.GetRoot()
+                .DescendantNodes()
+                .OfType<AttributeSyntax>()
+                .Single();
+
+            Assert.AreEqual(EncodeHelpers.GuidAttributeName, guidAttribute.Name.ToString());
+        }
+    }
+}


### PR DESCRIPTION
Generated C# can define a type named `Windows`, which causes synthesized `Windows.Win32.Foundation.Metadata.Guid` attributes to bind against that type instead of the root namespace. Qualify the attribute with `global::` everywhere it is generated or recognized, and share the spelling so detection stays aligned with synthesis. Add regression coverage for both Guid constant conversion paths and compile a representative namespace-shadowing case.