### PR TITLE
Qualify generated type names shadowed by namespaces

### DIFF
--- a/sources/ClangSharpSourceToWinmd/ClangSharpSourceCompilation.cs
+++ b/sources/ClangSharpSourceToWinmd/ClangSharpSourceCompilation.cs
@@ -316,6 +316,8 @@ namespace ClangSharpSourceToWinmd
                 comp = comp.AddReferences(MetadataReference.CreateFromFile(netstandardPath));
             }
 
+            comp = ShadowedTypeNameQualifier.QualifyShadowedTypeNames(comp, tree => WriteTree(tree, tree.FilePath));
+
             Console.WriteLine($"  {OutputUtils.FormatTimespan(watch.Elapsed)}");
             ShowMemory();
 

--- a/sources/ClangSharpSourceToWinmd/ShadowedTypeNameQualifier.cs
+++ b/sources/ClangSharpSourceToWinmd/ShadowedTypeNameQualifier.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace ClangSharpSourceToWinmd
+{
+    /// <summary>
+    /// Qualifies references to generated types whose simple name matches a top-level namespace.
+    /// C# binds such a name to the namespace before it considers types brought in by using
+    /// directives, so an unqualified reference from another namespace fails to compile even though
+    /// the type is imported.
+    /// </summary>
+    public static class ShadowedTypeNameQualifier
+    {
+        public static CSharpCompilation QualifyShadowedTypeNames(CSharpCompilation compilation, Action<SyntaxTree> treeChangedCallback = null)
+        {
+            var shadowedTypes = GetShadowedTypes(compilation);
+            if (shadowedTypes.Count == 0)
+            {
+                return compilation;
+            }
+
+            foreach (var tree in compilation.SyntaxTrees.ToArray())
+            {
+                var rewriter = new TreeRewriter(compilation.GetSemanticModel(tree), shadowedTypes);
+                var root = tree.GetRoot();
+                var newRoot = rewriter.Visit(root);
+                if (newRoot != root)
+                {
+                    var newTree = tree.WithRootAndOptions(newRoot, tree.Options);
+                    compilation = compilation.ReplaceSyntaxTree(tree, newTree);
+
+                    treeChangedCallback?.Invoke(newTree);
+                }
+            }
+
+            return compilation;
+        }
+
+        private static Dictionary<string, string> GetShadowedTypes(CSharpCompilation compilation)
+        {
+            // Namespaces from references count too. The generated sources are usually the only
+            // place a type shares a name with a namespace defined by something they reference.
+            var namespaceNames = new HashSet<string>(compilation.GlobalNamespace.GetNamespaceMembers().Select(n => n.Name), StringComparer.Ordinal);
+
+            var ambiguousNames = new HashSet<string>(StringComparer.Ordinal);
+            var shadowedTypes = new Dictionary<string, string>(StringComparer.Ordinal);
+
+            foreach (var type in GetTypes(compilation.Assembly.GlobalNamespace))
+            {
+                if (!namespaceNames.Contains(type.Name))
+                {
+                    continue;
+                }
+
+                string qualifiedName = type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+                if (shadowedTypes.TryGetValue(type.Name, out string existingName) && existingName != qualifiedName)
+                {
+                    // More than one generated type carries the shadowed name, so no single
+                    // qualified name can replace an unqualified reference to it.
+                    ambiguousNames.Add(type.Name);
+                }
+                else
+                {
+                    shadowedTypes[type.Name] = qualifiedName;
+                }
+            }
+
+            foreach (string ambiguousName in ambiguousNames)
+            {
+                shadowedTypes.Remove(ambiguousName);
+            }
+
+            return shadowedTypes;
+        }
+
+        private static IEnumerable<INamedTypeSymbol> GetTypes(INamespaceSymbol namespaceSymbol)
+        {
+            foreach (var type in namespaceSymbol.GetTypeMembers())
+            {
+                yield return type;
+            }
+
+            foreach (var childNamespace in namespaceSymbol.GetNamespaceMembers())
+            {
+                foreach (var type in GetTypes(childNamespace))
+                {
+                    yield return type;
+                }
+            }
+        }
+
+        private class TreeRewriter : CSharpSyntaxRewriter
+        {
+            private SemanticModel model;
+            private Dictionary<string, string> shadowedTypes;
+
+            public TreeRewriter(SemanticModel model, Dictionary<string, string> shadowedTypes)
+            {
+                this.model = model;
+                this.shadowedTypes = shadowedTypes;
+            }
+
+            public override SyntaxNode VisitIdentifierName(IdentifierNameSyntax node)
+            {
+                if (!this.shadowedTypes.TryGetValue(node.Identifier.ValueText, out string qualifiedName) ||
+                    !IsPotentialTypeReference(node) ||
+                    !this.BoundToNamespace(node))
+                {
+                    return base.VisitIdentifierName(node);
+                }
+
+                return SyntaxFactory.ParseName(qualifiedName).WithTriviaFrom(node);
+            }
+
+            private static bool IsPotentialTypeReference(IdentifierNameSyntax node)
+            {
+                // The left-most name of a dotted name refers to the namespace, not the type.
+                if (node.Parent is QualifiedNameSyntax qualifiedName && qualifiedName.Left == node)
+                {
+                    return false;
+                }
+
+                if (node.Parent is MemberAccessExpressionSyntax memberAccess && memberAccess.Expression == node)
+                {
+                    return false;
+                }
+
+                // Using and namespace declarations always name a namespace.
+                SyntaxNode outerName = node;
+                while (outerName.Parent is NameSyntax)
+                {
+                    outerName = outerName.Parent;
+                }
+
+                return !(outerName.Parent is UsingDirectiveSyntax || outerName.Parent is BaseNamespaceDeclarationSyntax);
+            }
+
+            private bool BoundToNamespace(IdentifierNameSyntax node)
+            {
+                var symbolInfo = this.model.GetSymbolInfo(node);
+                return symbolInfo.Symbol is INamespaceSymbol || symbolInfo.CandidateSymbols.Any(symbol => symbol is INamespaceSymbol);
+            }
+        }
+    }
+}

--- a/tests/ClangSharpSourceToWinmdTests/ShadowedTypeNameQualifierTests.cs
+++ b/tests/ClangSharpSourceToWinmdTests/ShadowedTypeNameQualifierTests.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Linq;
+using ClangSharpSourceToWinmd;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ClangSharpSourceToWinmdTests
+{
+    [TestClass]
+    public class ShadowedTypeNameQualifierTests
+    {
+        [TestMethod]
+        public void QualifyShadowedTypeNames_TypeNamedAfterNamespace_IsReferenceableFromOtherNamespace()
+        {
+            CSharpCompilation compilation = CreateCompilation(@"
+using System;
+using Test.Public;
+
+namespace Test.Public
+{
+    public partial struct Windows
+    {
+        public int Count;
+    }
+}
+
+namespace Windows.Win32.Foundation
+{
+    public partial struct HWND
+    {
+        public IntPtr Value;
+    }
+}
+
+namespace Test.Internal
+{
+    public unsafe partial struct Shell
+    {
+        public Windows* ActiveWindow;
+
+        public Windows[] AllWindows;
+
+        public Windows.Win32.Foundation.HWND Handle;
+
+        public static Windows* GetWindows(Windows** windows, delegate* unmanaged<Windows*, int> callback) => null;
+    }
+}");
+
+            Assert.AreEqual("CS0118", GetErrors(compilation).Select(error => error.Id).FirstOrDefault());
+
+            compilation = ShadowedTypeNameQualifier.QualifyShadowedTypeNames(compilation);
+
+            Diagnostic[] errors = GetErrors(compilation);
+            Assert.AreEqual(0, errors.Length, string.Join(Environment.NewLine, errors.Select(error => error.ToString())));
+        }
+
+        [TestMethod]
+        public void QualifyShadowedTypeNames_LeavesNamespaceReferencesAlone()
+        {
+            const string Source = @"
+using System;
+using Test.Public;
+using Windows.Win32.Foundation;
+
+namespace Test.Public
+{
+    public partial struct Windows
+    {
+        public int Count;
+    }
+}
+
+namespace Windows.Win32.Foundation
+{
+    public partial struct HWND
+    {
+        public IntPtr Value;
+    }
+}
+
+namespace Test.Internal
+{
+    public partial struct Shell
+    {
+        public Windows.Win32.Foundation.HWND Handle;
+
+        public HWND OtherHandle;
+    }
+}";
+
+            CSharpCompilation compilation = CreateCompilation(Source);
+
+            Assert.AreEqual(0, GetErrors(compilation).Length);
+
+            compilation = ShadowedTypeNameQualifier.QualifyShadowedTypeNames(compilation);
+
+            Assert.AreEqual(Source, compilation.SyntaxTrees.Single().ToString());
+        }
+
+        [TestMethod]
+        public void QualifyShadowedTypeNames_AmbiguousShadowedNameIsLeftAlone()
+        {
+            const string Source = @"
+using System;
+
+namespace Test.Public
+{
+    public partial struct Windows
+    {
+        public int Count;
+    }
+}
+
+namespace Test.Internal
+{
+    public partial struct Windows
+    {
+        public int Count;
+    }
+}
+
+namespace Windows.Win32.Foundation
+{
+    public partial struct HWND
+    {
+        public IntPtr Value;
+    }
+}";
+
+            CSharpCompilation compilation = CreateCompilation(Source);
+
+            compilation = ShadowedTypeNameQualifier.QualifyShadowedTypeNames(compilation);
+
+            Assert.AreEqual(Source, compilation.SyntaxTrees.Single().ToString());
+        }
+
+        private static CSharpCompilation CreateCompilation(string source)
+        {
+            return CSharpCompilation.Create(
+                "ShadowedTypeNameTest",
+                new[] { CSharpSyntaxTree.ParseText(source) },
+                new[] { MetadataReference.CreateFromFile(typeof(object).Assembly.Location) },
+                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true));
+        }
+
+        private static Diagnostic[] GetErrors(CSharpCompilation compilation)
+        {
+            return compilation.GetDiagnostics()
+                .Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+                .ToArray();
+        }
+    }
+}


### PR DESCRIPTION
Generating metadata for a library that declares a type whose simple name matches a top-level namespace — an interface named `Windows`, for example — fails to emit. The scraper writes those references unqualified, and C# binds a bare `Windows` to the `Windows` namespace before it considers the type imported by a using directive, so `ClangSharpSourceToWinmd` reports `CS0118: 'Windows' is a namespace but is used like a type` for every reference outside the type's own namespace. Only the declaring namespace can use the type, so the winmd can't be produced at all.

Visual Studio's interop winmd generation hit this with EnvDTE's `Windows` interface and had to rewrite the generated sources before emit to get past it.

The emitter now qualifies such references with the type's `global::`-qualified name. The pass runs once the compilation exists so namespaces contributed by references count, and it only rewrites a name that currently binds to a namespace in a position where a type is required. Names that legitimately denote a namespace — the left side of a dotted name, using directives, namespace declarations — are left alone, as is a shadowed name shared by more than one generated type, since no single qualified name would be correct. A using alias is not an option here: it collides with the same-named namespace (`CS0576`).

Same shape of fix as #2300, which handled the synthesized `Guid` attribute for this scenario.

Regression tests cover pointer, array, function-pointer, and qualified-name references to a shadowed type, plus the cases that must not be rewritten.